### PR TITLE
Create new CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,8 @@ jobs:
         type: env_var_name
       aws-secret-access-key:
         type: env_var_name
+      AWS_CERTIFICATE_ARN:
+        type: string
     steps:
       - checkout
       - aws-cli/setup:
@@ -84,6 +86,7 @@ jobs:
             export NEXT_PUBLIC_API_URL=<< parameters.API_URL >>
             export NEXT_PUBLIC_GTM_ID=<< parameters.GTM_ID >>
             export NEXT_PUBLIC_SINGLEVIEW_URL=<< parameters.SINGLEVIEW_URL >>
+            export AWS_CERTIFICATE_ARN=<< parameters.AWS_CERTIFICATE_ARN >>
             yarn
             yarn build
             yarn --production=true
@@ -100,6 +103,7 @@ workflows:
           API_URL: ${NEXT_PUBLIC_API_URL_STAGING}
           aws-access-key-id: AWS_ACCESS_KEY_ID_STAGING
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY_STAGING
+          AWS_CERTIFICATE_ARN: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_STAGING}
           filters:
@@ -117,6 +121,7 @@ workflows:
           API_URL: ${NEXT_PUBLIC_API_URL_PRODUCTION}
           aws-access-key-id: AWS_ACCESS_KEY_ID_PRODUCTION
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY_PRODUCTION
+          AWS_CERTIFICATE_ARN: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_PRODUCTION}
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,15 @@ jobs:
         type: string
       SINGLEVIEW_URL:
         type: string
+      aws-access-key-id:
+        type: env_var_name
+      aws-secret-access-key:
+        type: env_var_name
     steps:
       - checkout
       - aws-cli/setup:
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-access-key-id: << parameters.aws-access-key-id >>
+          aws-secret-access-key: << parameters.aws-secret-access-key >>
           aws-region: AWS_REGION
       - run: sudo yarn global add serverless
       - run:
@@ -94,6 +98,8 @@ workflows:
           name: deploy-staging
           stage_name: staging
           API_URL: ${NEXT_PUBLIC_API_URL_STAGING}
+          aws-access-key-id: AWS_ACCESS_KEY_ID_STAGING
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY_STAGING
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_STAGING}
           filters:
@@ -109,6 +115,8 @@ workflows:
           name: deploy-production
           stage_name: production
           API_URL: ${NEXT_PUBLIC_API_URL_PRODUCTION}
+          aws-access-key-id: AWS_ACCESS_KEY_ID_PRODUCTION
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY_PRODUCTION
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_PRODUCTION}
           requires:

--- a/serverless.yml
+++ b/serverless.yml
@@ -108,7 +108,7 @@ resources:
             - ${self:custom.aliases.${self:provider.stage}}
           PriceClass: PriceClass_100
           ViewerCertificate:
-            AcmCertificateArn: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
+            AcmCertificateArn: ${env:AWS_CERTIFICATE_ARN}
             MinimumProtocolVersion: TLSv1.2_2018
             SslSupportMethod: sni-only
           DefaultCacheBehavior:

--- a/serverless.yml
+++ b/serverless.yml
@@ -108,7 +108,7 @@ resources:
             - ${self:custom.aliases.${self:provider.stage}}
           PriceClass: PriceClass_100
           ViewerCertificate:
-            AcmCertificateArn: arn:aws:acm:us-east-1:402949050862:certificate/a2642366-3457-42b3-bd0b-06a9350c1cd8
+            AcmCertificateArn: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
             MinimumProtocolVersion: TLSv1.2_2018
             SslSupportMethod: sni-only
           DefaultCacheBehavior:
@@ -156,5 +156,5 @@ custom:
         - eu-west-2
         - amazonaws.com
   aliases:
-    staging: staging.frontdoor-snapshot.hackney.gov.uk
+    staging: frontdoor-snapshot-staging.hackney.gov.uk
     production: frontdoor-snapshot.hackney.gov.uk


### PR DESCRIPTION
These changes allow us to deploy to a staging and production environment with their own domain names, certificates, etc.

This app was forked from another HackIT app, the '[vulnerability checker](https://github.com/LBHackney-IT/housing-needs-vulnerabilities)'. These changes were necessary to distinguish it from that app.

These changes require new environment variables, which I have already added to the HackIT circleCI server.