### PR TITLE
Change which groups can access the app

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -43,7 +43,7 @@ functions:
       - http: ANY /{proxy+}
     environment:
       ENV: ${self:provider.stage}
-      ALLOWED_GROUPS: 'housingneeds-singleview-beta'
+      ALLOWED_GROUPS: 'inh-users-dev'
       JWT_SECRET: ${ssm:/common/hackney-jwt-secret}
       VULNERABILITIES_TABLE_NAME: ${self:provider.environment.VULNERABILITIES_TABLE}
       NEXT_PUBLIC_API_URL: https://${self:custom.aliases.${self:provider.stage}}/api
@@ -60,7 +60,7 @@ functions:
         - authorizer.js
         - node_modules/**
     environment:
-      ALLOWED_GROUPS: 'housingneeds-singleview-beta'
+      ALLOWED_GROUPS: 'inh-users-dev'
       JWT_SECRET: ${ssm:/common/hackney-jwt-secret}
 
 resources:


### PR DESCRIPTION
This PR changes the name of the Google groups (internal to Hackney) that are able to access this app.

(This previously being hard-coded to the 'wrong' value is the result of us forking an existing app.)