### PR TITLE
Change Airtable configuration

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -24,7 +24,7 @@ const snapshotGateway = new SnapshotGateway({
 const resourcesGateway = new ResourcesGateway({
   apiKey: process.env.AIRTABLE_API_KEY,
   baseId: process.env.AIRTABLE_BASE_ID,
-  baseUrl: process.env.AIRTABLE_BASE_URL || "https://api.airtable.com",
+  baseUrl: "https://api.airtable.com",
   tableNames: process.env.AIRTABLE_TABLE_NAMES.split(',')
 });
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -48,9 +48,9 @@ functions:
       VULNERABILITIES_TABLE_NAME: ${self:provider.environment.VULNERABILITIES_TABLE}
       NEXT_PUBLIC_API_URL: https://${self:custom.aliases.${self:provider.stage}}/api
       NEXT_PUBLIC_URL: https://${self:custom.aliases.${self:provider.stage}}
-      AIRTABLE_API_KEY: ${ssm:/vulnerabilities/airtable-api-key~true}
-      AIRTABLE_BASE_ID: ${ssm:/vulnerabilities/airtable-base-id}
-      AIRTABLE_TABLE_NAMES: ${ssm:/vulnerabilities/airtable-table-names}
+      AIRTABLE_API_KEY: ${ssm:/frontdoor-snapshot/airtable-api-key}
+      AIRTABLE_BASE_ID: ${ssm:/frontdoor-snapshot/airtable-base-id}
+      AIRTABLE_TABLE_NAMES: ${ssm:/frontdoor-snapshot/airtable-table-names}
 
   cf-snapshot-authorizer:
     name: ${self:service}-authorizer-${self:provider.stage}


### PR DESCRIPTION
Point these configuration values to keys that don't reflect the pre-fork version of this service. 

None of these keys existed in our AWS environment, so it was an opportunity to name them correctly!

At the time of writing, these SSM variables have been added in staging, but **not** in production.