### PR TITLE
Add static I-need-help URL for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
           name: Run integration tests
           command: |
             export NEXT_PUBLIC_API_URL=http://localhost:3000/api
+            export INH_URL=http://localhost:5000
             export VULNERABILITIES_TABLE_NAME=vulnerabilities
             export AIRTABLE_API_KEY=${AIRTABLE_API_KEY_INTEGRATION}
             export AIRTABLE_BASE_ID=${AIRTABLE_BASE_ID_INTEGRATION}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
         type: string
       SINGLEVIEW_URL:
         type: string
+      INH_URL:
+        type: string
       aws-access-key-id:
         type: env_var_name
       aws-secret-access-key:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
             export NEXT_PUBLIC_API_URL=<< parameters.API_URL >>
             export NEXT_PUBLIC_GTM_ID=<< parameters.GTM_ID >>
             export NEXT_PUBLIC_SINGLEVIEW_URL=<< parameters.SINGLEVIEW_URL >>
+            export INH_URL=<< parameters.INH_URL >>
             export AWS_CERTIFICATE_ARN=<< parameters.AWS_CERTIFICATE_ARN >>
             yarn
             yarn build
@@ -108,6 +109,7 @@ workflows:
           AWS_CERTIFICATE_ARN: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_STAGING}
+          INH_URL: ${INH_URL_STAGING}
           filters:
             branches:
               only: master
@@ -126,5 +128,6 @@ workflows:
           AWS_CERTIFICATE_ARN: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_PRODUCTION}
+          INH_URL: ${INH_URL_PRODUCTION}
           requires:
             - permit-deploy-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           name: Run integration tests
           command: |
             export NEXT_PUBLIC_API_URL=http://localhost:3000/api
-            export INH_URL=http://localhost:5000
+            export INH_URL=https://inh-admin-test.hackney.gov.uk
             export VULNERABILITIES_TABLE_NAME=vulnerabilities
             export AIRTABLE_API_KEY=${AIRTABLE_API_KEY_INTEGRATION}
             export AIRTABLE_BASE_ID=${AIRTABLE_BASE_ID_INTEGRATION}

--- a/cypress/integration/features/editSnapshot.spec.js
+++ b/cypress/integration/features/editSnapshot.spec.js
@@ -171,7 +171,7 @@ context('Edit snapshot', () => {
         .and(
           'have.attr',
           'href',
-          'http://localhost:5000/help-requests/edit/wub'
+          'https://inh-admin-test.hackney.gov.uk/help-requests/edit/wub'
         );
     });
   });

--- a/cypress/integration/pages/snapshotSummary.spec.js
+++ b/cypress/integration/pages/snapshotSummary.spec.js
@@ -75,7 +75,7 @@ context('Snapshot summary', () => {
         .and(
           'have.attr',
           'href',
-          'http://localhost:5000/help-requests/complete/dub'
+          'https://inh-admin-test.hackney.gov.uk/help-requests/complete/dub'
         );
     });
 

--- a/pages/snapshots/[id].test.js
+++ b/pages/snapshots/[id].test.js
@@ -138,7 +138,7 @@ describe('SnapshotSummary', () => {
       );
       expect(getByTestId('back-link-test')).toHaveAttribute(
         'href',
-        'http://localhost:5000/help-requests/edit/wub'
+        'https://inh-admin-test.hackney.gov.uk/help-requests/edit/wub'
       );
     });
   });

--- a/setupTests.js
+++ b/setupTests.js
@@ -16,5 +16,5 @@ process.env = Object.assign(process.env, {
   AIRTABLE_BASE_ID: 'not.a.real.base.id',
   AIRTABLE_TABLE_NAMES: 'not.a.real.table.name',
   NEXT_PUBLIC_SINGLEVIEW_URL: 'https://staging-singleview.hackney.gov.uk',
-  INH_URL: 'http://localhost:5000'
+  INH_URL: 'https://inh-admin-test.hackney.gov.uk'
 });


### PR DESCRIPTION
[These integration tests](https://github.com/LBHackney-IT/coronavirus-frontdoor-snapshot/blob/master/cypress/integration/pages/snapshotSummary.spec.js#L78)  currently rely on a `INH_URL` environment variable being a particular value. Since this variable is used to configure the real link that users see, I changed it to reflect our real environment - and the integration tests started failing.

This commit adds a hard-coded URL to the env vars passed to the integration tests, matching their expectations. I suspect there may be a better long-term way to do this.

(Unfortunately, the configuration in [setupTests.js](https://github.com/LBHackney-IT/coronavirus-frontdoor-snapshot/blob/master/setupTests.js) doesn't seem to affect the integration tests.)