### PR TITLE
Add basic version of conversational prompts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
           name: Run integration tests
           command: |
             export NEXT_PUBLIC_API_URL=http://localhost:3000/api
+            export NEXT_PUBLIC_SHOW_TOPIC_EXPLORER=true
             export INH_URL=https://inh-admin-test.hackney.gov.uk
             export VULNERABILITIES_TABLE_NAME=vulnerabilities
             export AIRTABLE_API_KEY=${AIRTABLE_API_KEY_INTEGRATION}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           name: Run integration tests
           command: |
             export NEXT_PUBLIC_API_URL=http://localhost:3000/api
-            export NEXT_PUBLIC_SHOW_TOPIC_EXPLORER=true
+            export SHOW_TOPIC_EXPLORER=true
             export INH_URL=https://inh-admin-test.hackney.gov.uk
             export VULNERABILITIES_TABLE_NAME=vulnerabilities
             export AIRTABLE_API_KEY=${AIRTABLE_API_KEY_INTEGRATION}

--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -1,17 +1,51 @@
+import React, { useState } from 'react';
+
 const TopicExplorer = (props) => {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [searchResults, setSearchResults] = useState([])
+
+  const onSearchChange = event => {
+    var results = []
+
+    for(const topic of props.topics) {
+      if(topic['tags'].includes(event.target.value)) {
+        results.push(topic.prompt);
+      }
+    }
+
+    setSearchTerm(event.target.value);
+    setSearchResults(results);
+  };
+
   return (
     <>
       <h1>Topics to explore</h1>
       <div className="govuk-form-group">
         <h2>How can we help?</h2>
-        <input type="text" className="govuk-input govuk-input--width-20" placeholder="e.g. food, mental health, lockdown" />
+        <input
+          type="text"
+          className="govuk-input govuk-input--width-20"
+          placeholder="e.g. food, mental health, lockdown"
+          value={searchTerm}
+          onChange={onSearchChange}
+        />
       </div>
-      <h2>Conversational prompts</h2>
-      <ul className="govuk-list">
-        <li><p>How are you doing/managing at the moment?</p></li>
-        <li><p>Do you have anyone around to help support you?</p></li>
-        <li><p>What are your main concerns at the moment?</p></li>
-      </ul>
+
+      { searchResults.length > 0 &&
+        <>
+          <h2>Conversational prompts</h2>
+          <ul className="govuk-list">
+            {searchResults}
+          </ul>
+        </>
+      }
+
+      { searchTerm.length > 0 &&
+        searchResults.length == 0 &&
+        <>
+          <p>No results for "{searchTerm}"</p>
+        </>
+      }
     </>
   )
 }

--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -6,9 +6,10 @@ const TopicExplorer = (props) => {
 
   const onSearchChange = event => {
     var results = []
+    const newSearchTerm = event.target.value.toLowerCase();
 
     for(const topic of props.topics) {
-      if(topic['tags'].includes(event.target.value)) {
+      if(topic['tags'].includes(newSearchTerm)) {
         results.push(topic.prompt);
       }
     }
@@ -35,7 +36,7 @@ const TopicExplorer = (props) => {
         <>
           <h2>Conversational prompts</h2>
           <ul className="govuk-list">
-            { searchResults.map((result) => <li>{ result }</li>) }
+            { searchResults.map(result => <li>{ result }</li>) }
           </ul>
         </>
       }

--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -1,0 +1,19 @@
+const TopicExplorer = (props) => {
+  return (
+    <>
+      <h1>Topics to explore</h1>
+      <div className="govuk-form-group">
+        <h2>How can we help?</h2>
+        <input type="text" className="govuk-input govuk-input--width-20" placeholder="e.g. food, mental health, lockdown" />
+      </div>
+      <h2>Conversational prompts</h2>
+      <ul className="govuk-list">
+        <li><p>How are you doing/managing at the moment?</p></li>
+        <li><p>Do you have anyone around to help support you?</p></li>
+        <li><p>What are your main concerns at the moment?</p></li>
+      </ul>
+    </>
+  )
+}
+
+export default TopicExplorer;

--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -35,7 +35,7 @@ const TopicExplorer = (props) => {
         <>
           <h2>Conversational prompts</h2>
           <ul className="govuk-list">
-            {searchResults}
+            { searchResults.map((result) => <li>{ result }</li>) }
           </ul>
         </>
       }

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -70,5 +70,21 @@ describe('TopicExplorer', () => {
       expect(screen.getByText('topic one')).toBeInTheDocument
       expect(screen.getByText('topic two')).toBeInTheDocument
     });
+
+    it('shows results for a search ignoring case', () => {
+      var topics = [
+        { prompt: 'topic one', tags: ['one'] },
+        { prompt: 'topic two', tags: ['two'] },
+      ]
+
+      render(<TopicExplorer topics={topics}/>);
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'ONE' },
+      });
+
+      expect(screen.getByText('topic one')).toBeInTheDocument
+      expect(screen.queryByText('topic two')).toBeNull
+    });
   });
 })

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import TopicExplorer from './index';
+
+describe('TopicExplorer', () => {
+  it('renders successfully', () => {
+    render(<TopicExplorer />);
+  })
+})

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -1,8 +1,33 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import TopicExplorer from './index';
 
 describe('TopicExplorer', () => {
-  it('renders successfully', () => {
-    render(<TopicExplorer />);
-  })
+  describe('renders successfully with props', () => {
+    var topics = [
+      { prompt: 'topic one', tags: ['one, 1, first'] },
+      { prompt: 'topic two', tags: ['two, 2, second'] },
+    ]
+
+    render(<TopicExplorer topics={topics}/>);
+
+    it('renders successfully', () => {
+      expect(screen.getByText('Conversational prompts')).toBeInTheDocument();
+    });
+
+    describe('with a search for topic one', () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'one' },
+      });
+
+      expect(screen.getByText('topic one')).toBeInTheDocument
+    });
+
+    xdescribe('with a search for topic two', () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'two' },
+      });
+
+      expect(screen.getByText('topic two')).toBeInTheDocument
+    });
+  });
 })

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -4,17 +4,30 @@ import TopicExplorer from './index';
 describe('TopicExplorer', () => {
   describe('renders successfully with props', () => {
     var topics = [
-      { prompt: 'topic one', tags: ['one, 1, first'] },
-      { prompt: 'topic two', tags: ['two, 2, second'] },
+      { prompt: 'topic one', tags: ['one'] },
+      { prompt: 'topic two', tags: ['two', 'second'] },
     ]
 
-    render(<TopicExplorer topics={topics}/>);
-
     it('renders successfully', () => {
-      expect(screen.getByText('Conversational prompts')).toBeInTheDocument();
+      render(<TopicExplorer topics={topics}/>);
+      expect(screen.getByText('How can we help?')).toBeInTheDocument();
     });
 
-    describe('with a search for topic one', () => {
+    it('shows no results for a tag that does not exist', () => {
+      render(<TopicExplorer topics={topics}/>);
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'giraffe' },
+      });
+
+      expect(screen.queryByText('topic one')).toBeNull();
+      expect(screen.queryByText('Conversational prompts')).toBeNull();
+      expect(screen.getByText('No results for "giraffe"')).toBeInTheDocument();
+    });
+
+    it('shows results for the first topic', () => {
+      render(<TopicExplorer topics={topics}/>);
+
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'one' },
       });
@@ -22,9 +35,21 @@ describe('TopicExplorer', () => {
       expect(screen.getByText('topic one')).toBeInTheDocument
     });
 
-    xdescribe('with a search for topic two', () => {
+    it('shows results for the second topic', () => {
+      render(<TopicExplorer topics={topics}/>);
+
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'two' },
+      });
+
+      expect(screen.getByText('topic two')).toBeInTheDocument
+    });
+
+    it('shows results searching for any matching tag', () => {
+      render(<TopicExplorer topics={topics}/>);
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'second' },
       });
 
       expect(screen.getByText('topic two')).toBeInTheDocument

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -54,5 +54,21 @@ describe('TopicExplorer', () => {
 
       expect(screen.getByText('topic two')).toBeInTheDocument
     });
+
+    it('shows all results for a matching tag', () => {
+      var topics = [
+        { prompt: 'topic one', tags: ['one', 'all'] },
+        { prompt: 'topic two', tags: ['two', 'all'] },
+      ]
+
+      render(<TopicExplorer topics={topics}/>);
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'all' },
+      });
+
+      expect(screen.getByText('topic one')).toBeInTheDocument
+      expect(screen.getByText('topic two')).toBeInTheDocument
+    });
   });
 })

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -5,9 +5,14 @@ context('Index page', () => {
     cy.injectAxe();
   });
 
-  describe('Loads page', () => {
-    it('has heading', () => {
-      cy.get('h1').should('have.text', 'Resource Finder');
+  describe('Page structure', () => {
+    it('has the right headings', () => {
+      cy.contains('Topics to explore').should('be.visible')
+      cy.contains('How can we help?').should('be.visible')
+      cy.contains('Resource Finder').should('be.visible')
+    });
+
+    it('has no content outside top-level headings', () => {
       cy.checkA11y('#content > h1', null, cy.terminalLog);
     });
   });

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,7 +4,7 @@ import { requestResources } from 'lib/api';
 import HttpStatusError from 'lib/api/domain/HttpStatusError';
 import { getTokenFromCookieHeader } from 'lib/utils/token';
 import VulnerabilitiesGrid from 'components/Feature/VulnerabilitiesGrid';
-
+import TopicExplorer from 'components/Feature/TopicExplorer';
 
 const Index = ({ resources, initialSnapshot, token }) => {
   const [errorMsg, setErrorMsg] = useState()
@@ -33,9 +33,11 @@ const Index = ({ resources, initialSnapshot, token }) => {
 
 
   const residentCoordinates = Promise.resolve(null)
-  
+
   return (
     <>
+      <TopicExplorer />
+      <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <h1>
         Resource Finder
       </h1>

--- a/pages/index.js
+++ b/pages/index.js
@@ -56,7 +56,7 @@ const Index = ({ resources, initialSnapshot, token }) => {
       <p>
       Enter a postcode to help filter the results by distance:
       </p>
-      <div class="govuk-form-group">
+      <div className="govuk-form-group">
       <p className="govuk-error-message">{genericPostcode && errorMsg}</p>
       <input
         className={'govuk-input govuk-!-width-one-quarter' + ((genericPostcode && errorMsg) ? " govuk-input--error" : "")}

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,7 +6,7 @@ import { getTokenFromCookieHeader } from 'lib/utils/token';
 import VulnerabilitiesGrid from 'components/Feature/VulnerabilitiesGrid';
 import TopicExplorer from 'components/Feature/TopicExplorer';
 
-const Index = ({ resources, initialSnapshot, token }) => {
+const Index = ({ resources, initialSnapshot, token, showTopicExplorer }) => {
   const [errorMsg, setErrorMsg] = useState()
   const { snapshot, loading, updateSnapshot } = useSnapshot(
     initialSnapshot.snapshotId,
@@ -45,8 +45,6 @@ const Index = ({ resources, initialSnapshot, token }) => {
     { prompt: 'Are you worried about something you need?', tags: ['lockdown'] },
     { prompt: '(Hackney has no additional local restrictions right now)', tags: ['lockdown'] },
   ]
-
-  const showTopicExplorer = process.env.NEXT_PUBLIC_SHOW_TOPIC_EXPLORER
 
   return (
     <>
@@ -99,11 +97,9 @@ Index.getInitialProps = async ({
     const token = getTokenFromCookieHeader(headers);
     const initialSnapshot = { vulnerabilities: [], assets: [], notes: null }
     const resources = await requestResources({ token });
-    return {
-      resources,
-      initialSnapshot,
-      token
-    };
+    const showTopicExplorer = process.env.SHOW_TOPIC_EXPLORER;
+
+    return { resources, initialSnapshot, token, showTopicExplorer };
   } catch (err) {
     console.log("Failed to load initial Props:" + err)
     res.writeHead(err instanceof HttpStatusError ? err.statusCode : 500).end();

--- a/pages/index.js
+++ b/pages/index.js
@@ -46,10 +46,16 @@ const Index = ({ resources, initialSnapshot, token }) => {
     { prompt: '(Hackney has no additional local restrictions right now)', tags: ['lockdown'] },
   ]
 
+  const showTopicExplorer = process.env.NEXT_PUBLIC_SHOW_TOPIC_EXPLORER
+
   return (
     <>
-      <TopicExplorer topics={topics}/>
-      <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+      { showTopicExplorer &&
+        <>
+          <TopicExplorer topics={topics}/>
+          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+        </>
+      }
       <h1>
         Resource Finder
       </h1>

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,9 +34,14 @@ const Index = ({ resources, initialSnapshot, token }) => {
 
   const residentCoordinates = Promise.resolve(null)
 
+  const topics = [
+    { prompt: 'topic one', tags: ['one'] },
+    { prompt: 'topic two', tags: ['two', 'second'] }
+  ]
+
   return (
     <>
-      <TopicExplorer />
+      <TopicExplorer topics={topics}/>
       <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <h1>
         Resource Finder

--- a/pages/index.js
+++ b/pages/index.js
@@ -35,8 +35,15 @@ const Index = ({ resources, initialSnapshot, token }) => {
   const residentCoordinates = Promise.resolve(null)
 
   const topics = [
-    { prompt: 'topic one', tags: ['one'] },
-    { prompt: 'topic two', tags: ['two', 'second'] }
+    { prompt: 'How are you feeling right now?', tags: ['mental health'] },
+    { prompt: 'Do you have anyone supporting you?', tags: ['mental health', 'lonely', 'loneliness'] },
+    { prompt: 'Do you talk to your family?', tags: ['lonely', 'loneliness'] },
+    { prompt: 'Are you able to shop for food?', tags: ['food'] },
+    { prompt: 'Do you know what food help is available in your area?', tags: ['food'] },
+    { prompt: '(We are unable to provide food directly)', tags: ['food'] },
+    { prompt: 'Have you seen the government guidance on local lockdowns?', tags: ['lockdown'] },
+    { prompt: 'Are you worried about something you need?', tags: ['lockdown'] },
+    { prompt: '(Hackney has no additional local restrictions right now)', tags: ['lockdown'] },
   ]
 
   return (


### PR DESCRIPTION
This PR adds a section above the "resource finder", showing prompts based on a search.

![search examples](https://user-images.githubusercontent.com/429326/91852480-d00cd300-ec58-11ea-959f-175b757f3a54.gif)

____

Things we could do next:
- taking in markdown "additional information" underneath questions
- splitting this into multiple components
- more complicated search results than "a question"
- pulling results from airtable instead of a hardcoded hash
- fuzzy search
- more custom styling