### PR TITLE
Add more information to conversational prompts w/Markdown

### DIFF
--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -36,7 +36,7 @@ const TopicExplorer = (props) => {
         <>
           <h2>Conversational prompts</h2>
           <ul className="govuk-list">
-            { searchResults.map(result => <li>{ result }</li>) }
+            { searchResults.map((result, i) => <li key={i}>{ result }</li>) }
           </ul>
         </>
       }

--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Markdown from 'markdown-to-jsx';
 
 const TopicExplorer = (props) => {
   const [searchTerm, setSearchTerm] = useState('')
@@ -9,8 +10,8 @@ const TopicExplorer = (props) => {
     const newSearchTerm = event.target.value.toLowerCase();
 
     for(const topic of props.topics) {
-      if(topic['tags'].includes(newSearchTerm)) {
-        results.push(topic.prompt);
+      if(topic.tags.includes(newSearchTerm)) {
+        results.push(topic);
       }
     }
 
@@ -35,8 +36,22 @@ const TopicExplorer = (props) => {
       { searchResults.length > 0 &&
         <>
           <h2>Conversational prompts</h2>
-          <ul className="govuk-list">
-            { searchResults.map((result, i) => <li key={i}>{ result }</li>) }
+          <ul className="govuk-list govuk-list--bullet">
+            { searchResults.map((result, i) =>
+              <li key={i}>
+                <p className="govuk-!-margin-bottom-1">
+                  { result.prompt }
+                </p>
+                <Markdown options={{
+                  overrides: { span: { props: {
+                    className: 'govuk-!-font-size-16',
+                    style: { color: '#505a5f' }
+                  }}}
+                }}>
+                  { result.supportingInformation ?? "" }
+                </Markdown>
+              </li>)
+            }
           </ul>
         </>
       }

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -63,4 +63,61 @@ describe('TopicExplorer', () => {
       expect(screen.getByText('topic one')).toBeInTheDocument
     });
   });
-})
+
+  describe('with topics with tags and further info', () => {
+    beforeEach(() => {
+      var topics = [
+        {
+          prompt: 'topic one',
+          supportingInformation: 'support info one',
+          tags: ['one']
+        },
+        {
+          prompt: 'topic two',
+          supportingInformation: 'support info two',
+          tags: ['two']
+        },
+      ]
+
+      render(<TopicExplorer topics={topics}/>);
+    });
+
+    it('shows no results initially', () => {
+      expect(screen.queryByText('Conversational prompts')).toBeNull();
+      expect(screen.queryByText('topic one')).toBeNull();
+      expect(screen.queryByText('topic two')).toBeNull();
+    });
+
+    it('searching for a tag shows all the related info', () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'one' },
+      });
+
+      expect(screen.getByText('topic one')).toBeInTheDocument
+      expect(screen.getByText('support info one')).toBeInTheDocument
+    });
+  });
+
+  describe('with markdown-formatted further info', () => {
+    beforeEach(() => {
+      var topics = [
+        {
+          prompt: 'topic one',
+          supportingInformation: "[click me](https://example.path/)",
+          tags: ['one']
+        }
+      ]
+
+      render(<TopicExplorer topics={topics}/>);
+    });
+
+    it('shows links', () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'one' },
+      });
+
+      expect(screen.getByRole('link')).toHaveTextContent('click me')
+      expect(screen.getByText('click me').href).toBe('https://example.path/')
+    });
+  });
+});

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -1,33 +1,44 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
 import TopicExplorer from './index';
 
 describe('TopicExplorer', () => {
-  describe('renders successfully with props', () => {
-    var topics = [
-      { prompt: 'topic one', tags: ['one'] },
-      { prompt: 'topic two', tags: ['two', 'second'] },
-    ]
+  describe('with no topics', () => {
+    beforeEach(() => {
+      var topics = []
+      render(<TopicExplorer topics={topics}/>);
+    });
 
     it('renders successfully', () => {
-      render(<TopicExplorer topics={topics}/>);
       expect(screen.getByText('How can we help?')).toBeInTheDocument();
     });
 
-    it('shows no results for a tag that does not exist', () => {
-      render(<TopicExplorer topics={topics}/>);
-
+    it('shows no results for a search', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'giraffe' },
       });
 
-      expect(screen.queryByText('topic one')).toBeNull();
       expect(screen.queryByText('Conversational prompts')).toBeNull();
       expect(screen.getByText('No results for "giraffe"')).toBeInTheDocument();
     });
+  });
 
-    it('shows results for the first topic', () => {
+  describe('with tagged topics', () => {
+    beforeEach(() => {
+      var topics = [
+        { prompt: 'topic one', tags: ['one', 'all'] },
+        { prompt: 'topic two', tags: ['two', 'second', 'all'] },
+      ]
+
       render(<TopicExplorer topics={topics}/>);
+    });
 
+    it('shows no results initially', () => {
+      expect(screen.queryByText('Conversational prompts')).toBeNull();
+      expect(screen.queryByText('topic one')).toBeNull();
+      expect(screen.queryByText('topic two')).toBeNull();
+    });
+
+    it('searching for a tag shows a matching topic', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'one' },
       });
@@ -35,34 +46,7 @@ describe('TopicExplorer', () => {
       expect(screen.getByText('topic one')).toBeInTheDocument
     });
 
-    it('shows results for the second topic', () => {
-      render(<TopicExplorer topics={topics}/>);
-
-      fireEvent.change(screen.getByRole('textbox'), {
-        target: { value: 'two' },
-      });
-
-      expect(screen.getByText('topic two')).toBeInTheDocument
-    });
-
-    it('shows results searching for any matching tag', () => {
-      render(<TopicExplorer topics={topics}/>);
-
-      fireEvent.change(screen.getByRole('textbox'), {
-        target: { value: 'second' },
-      });
-
-      expect(screen.getByText('topic two')).toBeInTheDocument
-    });
-
-    it('shows all results for a matching tag', () => {
-      var topics = [
-        { prompt: 'topic one', tags: ['one', 'all'] },
-        { prompt: 'topic two', tags: ['two', 'all'] },
-      ]
-
-      render(<TopicExplorer topics={topics}/>);
-
+    it('searching for a tag shows all matching results', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'all' },
       });
@@ -71,20 +55,12 @@ describe('TopicExplorer', () => {
       expect(screen.getByText('topic two')).toBeInTheDocument
     });
 
-    it('shows results for a search ignoring case', () => {
-      var topics = [
-        { prompt: 'topic one', tags: ['one'] },
-        { prompt: 'topic two', tags: ['two'] },
-      ]
-
-      render(<TopicExplorer topics={topics}/>);
-
+    it('ignores case when searching', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'ONE' },
       });
 
       expect(screen.getByText('topic one')).toBeInTheDocument
-      expect(screen.queryByText('topic two')).toBeNull
     });
   });
 })

--- a/components/Feature/TopicExplorer/topics.js
+++ b/components/Feature/TopicExplorer/topics.js
@@ -1,0 +1,84 @@
+const topics = () => [
+  {
+    prompt: 'Common symptoms',
+    supportingInformation: 'High temperature. A new, continuous cough. Loss or change to your sense of smell or taste.',
+    tags: ['covid', 'coronavirus', 'coronovirus', 'cv', 'lockdown', 'test']
+  },
+  {
+    prompt: 'If you have COVID symptoms, do not go to your GP, pharmacy or a hospital.',
+    tags: ['covid', 'coronavirus', 'coronovirus', 'cv', 'lockdown']
+  },
+  {
+    prompt: 'How does testing work?',
+    supportingInformation: "Anyone with coronavirus symptoms can get a test. (Search 'test' for more info.)",
+    tags: ['covid', 'coronavirus', 'coronovirus', 'cv', 'lockdown']
+  },
+  {
+    prompt: 'Home test or test site?',
+    supportingInformation: 'There may be worries about leaving the house. Past day 5 of symptoms, home tests are not suitable.',
+    tags: ['test']
+  },
+  {
+    prompt: 'How many days have you had symptoms for?',
+    supportingInformation: 'You need to get a test done in the first 5 days of having symptoms.',
+    tags: ['test']
+  },
+  {
+    prompt: 'Useful links',
+    supportingInformation: "[The government guidance on testing](https://www.gov.uk/get-coronavirus-test)",
+    tags: ['test']
+  },
+  {
+    prompt: "Do you have anyone you can talk to if you're worried?",
+    supportingInformation: "Friends, family, citizen's advice",
+    tags: ['scam']
+  },
+  {
+    prompt: "Have you seen our advice on avoiding scams?",
+    supportingInformation: "[Our COVID scam advice page](https://hackney.gov.uk/coronavirus-scams)",
+    tags: ['scam']
+  },
+  {
+    prompt: 'Can you access food?',
+    supportingInformation: 'Are you able to leave the house? Can anyone shop for you?',
+    tags: ['food', 'shopping', 'hungry']
+  },
+  {
+    prompt: 'Online shopping',
+    supportingInformation: 'Can you shop online? Can you pay for food with a card instead of cash?',
+    tags: ['food', 'shopping', 'hungry']
+  },
+  {
+    prompt: 'Can you afford food?',
+    supportingInformation: "Related: Talk about affording heating or other hardship.",
+    tags: ['food', 'shopping', 'hungry']
+  },
+  {
+    prompt: 'Can you afford fuel?',
+    supportingInformation: 'Citizen’s Advice have fuel vouchers available for families in hardship. Residents can get more detail by calling **020 8355 4472** or emailing **advice@eastendcab.org.uk**.',
+    tags: ['heat', 'cold', 'fuel', 'heating']
+  },
+  {
+    prompt: 'Hackney Council helplines',
+    supportingInformation: 'Benefits: **020 8356 3399**, Council Tax: **020 8356 3154**',
+    tags: ['heat', 'cold', 'fuel', 'heating', 'benefits']
+  }
+]
+
+export default topics
+
+// scam, government, central, contacted, contact
+// https://hackney.gov.uk/coronavirus-scams
+
+// food
+// Can you access food?
+//// Are you able to leave the house at the moment?
+//// Do you have friends/family/neighbours who can help?
+//// Do you have online access?
+// Can you afford food?
+// Morrisons in X are now delivering food
+
+// benefits, money
+
+// Benefits Helpline: *020 8356 3399**.
+// [Hackney Council's Council’s website](https://hackney.gov.uk/coronavirus-financial-support) for advice.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12907,6 +12907,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-to-jsx": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+      "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
+      "requires": {
+        "prop-types": "^15.6.2",
+        "unquote": "^1.1.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cookie-parser": "^1.4.5",
     "govuk-frontend": "^3.6.0",
     "jsonwebtoken": "^8.5.1",
+    "markdown-to-jsx": "^6.11.4",
     "moment": "^2.26.0",
     "nanoid": "^3.1.10",
     "next": "^9.4.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,7 @@ import HttpStatusError from 'lib/api/domain/HttpStatusError';
 import { getTokenFromCookieHeader } from 'lib/utils/token';
 import VulnerabilitiesGrid from 'components/Feature/VulnerabilitiesGrid';
 import TopicExplorer from 'components/Feature/TopicExplorer';
+import topics from 'components/Feature/TopicExplorer/topics'
 
 const Index = ({ resources, initialSnapshot, token, showTopicExplorer }) => {
   const [errorMsg, setErrorMsg] = useState()
@@ -34,23 +35,11 @@ const Index = ({ resources, initialSnapshot, token, showTopicExplorer }) => {
 
   const residentCoordinates = Promise.resolve(null)
 
-  const topics = [
-    { prompt: 'How are you feeling right now?', tags: ['mental health'] },
-    { prompt: 'Do you have anyone supporting you?', tags: ['mental health', 'lonely', 'loneliness'] },
-    { prompt: 'Do you talk to your family?', tags: ['lonely', 'loneliness'] },
-    { prompt: 'Are you able to shop for food?', tags: ['food'] },
-    { prompt: 'Do you know what food help is available in your area?', tags: ['food'] },
-    { prompt: '(We are unable to provide food directly)', tags: ['food'] },
-    { prompt: 'Have you seen the government guidance on local lockdowns?', tags: ['lockdown'] },
-    { prompt: 'Are you worried about something you need?', tags: ['lockdown'] },
-    { prompt: '(Hackney has no additional local restrictions right now)', tags: ['lockdown'] },
-  ]
-
   return (
     <>
       { showTopicExplorer &&
         <>
-          <TopicExplorer topics={topics}/>
+          <TopicExplorer topics={topics()}/>
           <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
         </>
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7936,6 +7936,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-to-jsx@^6.11.4:
+  version "6.11.4"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
+  integrity sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==
+  dependencies:
+    prop-types "^15.6.2"
+    unquote "^1.1.0"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -11435,6 +11443,11 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+unquote@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
+  integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This version still pulls from hard-coded prompts rather than Airtable. 

I've tweaked the prompts so that this shows off the functionality a little better, and moved them to a flat file for easier future edits.
___

NEW:

![image](https://user-images.githubusercontent.com/429326/92112529-d67c8580-ede5-11ea-9833-53d33cff3316.png)

OLD:

![image](https://user-images.githubusercontent.com/429326/92112650-075cba80-ede6-11ea-846f-55e935dfc4ae.png)

