### PR TITLE
Fix broken width caused by too many tags

### DIFF
--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -20,3 +20,13 @@ margin-bottom: 0px;
   font-size: 1em !important;
   line-height: 1.2em !important;
 }
+
+.ResourceCard_tags__1Zgh3 {
+float:left;
+margin-bottom: 5px;
+}
+
+.ResourceCard_resource__-Szc9 .ResourceCard_tags__container__3A8cx {
+  margin-bottom: 0px;
+  display: inherit;
+}


### PR DESCRIPTION
**What**  
The width of each resource should now stick to the 45% previously in place. Tags now wrap around on to another line if required.
![image](https://user-images.githubusercontent.com/64266608/92121306-0762b780-edf2-11ea-9e0a-bed9b1b168b8.png)

The fix should look like the below:
![image](https://user-images.githubusercontent.com/64266608/92121497-3f69fa80-edf2-11ea-9e1d-4f37e6824dfd.png)


**Why**  
So that the resources correctly display in 2 columns.

**Anything else?** 
N/A