### PR TITLE
Fix additional vertical spacing that appears between resource title and view more information button

### DIFF
--- a/components/Form/SummaryList/index.js
+++ b/components/Form/SummaryList/index.js
@@ -1,6 +1,6 @@
 const SummaryList = ({ name, entries, customStyle }) => (
-  <div className="govuk-form-group">
-    <dl className={"govuk-summary-list " + customStyle} id={name}>
+  <div>
+    <dl className={customStyle} id={name}>
       {Object.entries(entries).map(([key, value], index) => {
         return (
           


### PR DESCRIPTION
This involved removing 2 classes that were adding additional vertical margin, as it caused a large gap to appear on all resources that were not FOOD related

**What**  
Removes a large gap by removing 2 classes that were not required.

Before:
![image](https://user-images.githubusercontent.com/64266608/92124654-f4ea7d00-edf5-11ea-9514-42e9464e1007.png)


After:
![image](https://user-images.githubusercontent.com/64266608/92124592-de442600-edf5-11ea-9310-e0dd4240eff4.png)


**Why**  
A large gap is visible on non FOOD related resources

**Anything else?**  
This involved removing 2 classes that were adding additional vertical margin, as it caused a large gap to appear on all resources that were not FOOD related
