### PR TITLE
Change placeholder search terms

### DIFF
--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -43,8 +43,8 @@ const TopicExplorer = (props) => {
         />
         <div id='example-search'>Try a search for{' '}
           <button className='button-as-link govuk-!-padding-0' data-search-term='food' onClick={populateInput} data-testid='food'>food</button>,{' '}
-          <button className='button-as-link govuk-!-padding-0' data-search-term='mental health' onClick={populateInput}>mental health</button>, or{' '}
-          <button className='button-as-link govuk-!-padding-0' data-search-term='debt'onClick={populateInput}>debt</button>
+          <button className='button-as-link govuk-!-padding-0' data-search-term='health' onClick={populateInput}>health</button>, or{' '}
+          <button className='button-as-link govuk-!-padding-0' data-search-term='benefits'onClick={populateInput}>benefits</button>
         </div>
       </div>
 

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -77,17 +77,17 @@ context('Index page', () => {
     })
 
 
-    it("can show mental health example prompts", () => {
-      cy.get("#example-search").contains('mental health').click();
-      cy.get('input').should('have.value', 'mental health')
+    it("can show health example prompts", () => {
+      cy.get("#example-search").contains('health').click();
+      cy.get('input').should('have.value', 'health')
     })
 
 
-    it("can show debt example prompts", () => {
-      cy.get("#example-search").contains('debt').click();
-      cy.get('input').should('have.value', 'debt')
+    it("can show benefits prompts", () => {
+      cy.get("#example-search").contains('benefits').click();
+      cy.get('input').should('have.value', 'benefits')
     })
 
   })
-  
+
 });


### PR DESCRIPTION
Since we're not connected to airtable prompts yet, the old terms didn't show any results. These new words have matches in the example prompts.

NEW:

![image](https://user-images.githubusercontent.com/429326/92374238-5dd43c80-f0f7-11ea-9e35-ea893a3dc624.png)
