### PR TITLE
Show prompts on call journey

### DIFF
--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -32,7 +32,6 @@ const TopicExplorer = (props) => {
   }
   return (
     <>
-      <h1>Topics to explore</h1>
       <div className="govuk-form-group">
         <h2>How can we help?</h2>
         <input

--- a/cypress/integration/features/editSnapshot.spec.js
+++ b/cypress/integration/features/editSnapshot.spec.js
@@ -20,7 +20,6 @@ context('Edit snapshot', () => {
     cy.task('deleteSnapshot', '1');
   });
 
-
   it("Adds resources to the summary list", () => {
     cy.visit(`/snapshots/1`);
     cy.get('[data-testid=accordion-item]').eq(0).click();
@@ -52,13 +51,14 @@ context('Edit snapshot', () => {
       .should('contain', 'Resources')
       .and('contain', 'Shirdi Sai Baba Temple');
   })
-  
+
   describe('Edit snapshot', () => {
     it('Displays editable snapshot if there are no assets, vulnerabilites and notes added', () => {
       cy.visit(`/snapshots/1`);
-      cy.get('h1').should('contain', 'Phineas Flynn');
 
-      cy.get('h2').should('contain', 'Things to explore with the resident');
+      cy.contains('Phineas Flynn').should('be.visible')
+      cy.contains('How can we help?').should('be.visible')
+      cy.contains('Things to explore with the resident').should('be.visible')
 
       cy.get('[data-testid=accordion-item]')
         .should('contain', 'Financial stability')

--- a/pages/index.js
+++ b/pages/index.js
@@ -39,6 +39,7 @@ const Index = ({ resources, initialSnapshot, token, showTopicExplorer }) => {
     <>
       { showTopicExplorer &&
         <>
+          <h1>Topics to explore</h1>
           <TopicExplorer topics={topics()}/>
           <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
         </>

--- a/pages/snapshots/[id].js
+++ b/pages/snapshots/[id].js
@@ -7,8 +7,10 @@ import { Button, TextArea } from 'components/Form';
 import VulnerabilitiesGrid from 'components/Feature/VulnerabilitiesGrid';
 import { convertIsoDateToString, convertIsoDateToYears } from 'lib/utils/date';
 import geoCoordinates from 'lib/api/utils/geoCoordinates';
+import TopicExplorer from 'components/Feature/TopicExplorer';
+import topics from 'components/Feature/TopicExplorer/topics'
 
-const SnapshotSummary = ({ resources, initialSnapshot, token }) => {
+const SnapshotSummary = ({ resources, initialSnapshot, token, showTopicExplorer }) => {
   const { snapshot, loading, updateSnapshot } = useSnapshot(
     initialSnapshot.snapshotId,
     {
@@ -88,10 +90,10 @@ const SnapshotSummary = ({ resources, initialSnapshot, token }) => {
   let customerId = snapshot.systemIds?.[0];
   const residentCoordinates = geoCoordinates(postcode);
   const INH_URL = process.env.INH_URL
-  
+
   return (
     <>
-      <div>      
+      <div>
         { editSnapshot && customerId && (
           <a
           href={`${INH_URL}/help-requests/edit/${customerId}`}
@@ -115,6 +117,12 @@ const SnapshotSummary = ({ resources, initialSnapshot, token }) => {
           Aged {convertIsoDateToYears(dob)} ({convertIsoDateToString(dob)})
         </span>
       )}
+      { showTopicExplorer &&
+        <>
+          <TopicExplorer topics={topics()}/>
+          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+        </>
+      }
       {editSnapshot && (
         <>
           <VulnerabilitiesGrid
@@ -220,10 +228,12 @@ SnapshotSummary.getInitialProps = async ({
     const token = getTokenFromCookieHeader(headers);
     const initialSnapshot = await requestSnapshot(id, { token });
     const resources = await requestResources({ token });
+    const showTopicExplorer = process.env.SHOW_TOPIC_EXPLORER;
     return {
       resources,
       initialSnapshot,
-      token
+      token,
+      showTopicExplorer
     };
   } catch (err) {
     res.writeHead(err instanceof HttpStatusError ? err.statusCode : 500).end();

--- a/pages/snapshots/[id].js
+++ b/pages/snapshots/[id].js
@@ -216,9 +216,6 @@ SnapshotSummary.getInitialProps = async ({
   req: { headers },
   res
 }) => {
-  console.log(process.env.NEXT_PUBLIC_API_URL);
-  console.log(process.env.NEXT_PUBLIC_GTM_ID);
-  console.log(process.env.NEXT_PUBLIC_SINGLEVIEW_URL);
   try {
     const token = getTokenFromCookieHeader(headers);
     const initialSnapshot = await requestSnapshot(id, { token });


### PR DESCRIPTION
This PR adds the new conversational prompts to the 'edit snapshot' view, meaning that they'll be visible to people clicking through the 'I need help' service.

These being disparate views is likely to trip up other people in the future, but bringing those views together would take too much time right now, sadly.

![image](https://user-images.githubusercontent.com/429326/92398292-2a59d800-f120-11ea-96b4-dea278c5f5c8.png)
