### PR TITLE
Hook up topic explorer to Airtable

### DIFF
--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -4,15 +4,18 @@ import Markdown from 'markdown-to-jsx';
 const TopicExplorer = (props) => {
   const [searchTerm, setSearchTerm] = useState('')
   const [searchResults, setSearchResults] = useState([])
-
+  
   const getSearchResults = (searchTerm) => {
     var results = []
-    const newSearchTerm = searchTerm.toLowerCase();
+    const newSearchTerm = searchTerm.toLocaleLowerCase();
 
     for(const topic of props.topics) {
-      if(topic.tags.includes(newSearchTerm)) {
-        results.push(topic);
-      }
+      const promptTags = topic.promptTags
+      promptTags.forEach(tag => {
+        if(tag.toLocaleLowerCase() == newSearchTerm){
+          results.push(topic);
+        }
+      });
     }
     return results
   }

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -25,8 +25,8 @@ describe('TopicExplorer', () => {
   describe('with tagged topics', () => {
     beforeEach(() => {
       var topics = [
-        { prompt: 'topic one', tags: ['one', 'all'] },
-        { prompt: 'topic two', tags: ['two', 'second', 'all'] },
+        { prompt: 'topic one', promptTags: ['One', 'All'] },
+        { prompt: 'topic two', promptTags: ['Two', 'Second', 'All'] },
       ]
 
       render(<TopicExplorer topics={topics}/>);
@@ -70,12 +70,12 @@ describe('TopicExplorer', () => {
         {
           prompt: 'topic one',
           supportingInformation: 'support info one',
-          tags: ['one']
+          promptTags: ['One']
         },
         {
           prompt: 'topic two',
           supportingInformation: 'support info two',
-          tags: ['two']
+          promptTags: ['Two']
         },
       ]
 
@@ -104,7 +104,7 @@ describe('TopicExplorer', () => {
         {
           prompt: 'topic one',
           supportingInformation: "[click me](https://example.path/)",
-          tags: ['one']
+          promptTags: ['One']
         }
       ]
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,12 @@
 import { useState } from 'react';
 import useSnapshot from 'lib/api/utils/useSnapshot';
-import { requestResources } from 'lib/api';
+import { requestResources, requestPrompts } from 'lib/api';
 import HttpStatusError from 'lib/api/domain/HttpStatusError';
 import { getTokenFromCookieHeader } from 'lib/utils/token';
 import VulnerabilitiesGrid from 'components/Feature/VulnerabilitiesGrid';
 import TopicExplorer from 'components/Feature/TopicExplorer';
-import topics from 'components/Feature/TopicExplorer/topics'
 
-const Index = ({ resources, initialSnapshot, token, showTopicExplorer }) => {
+const Index = ({ resources, initialSnapshot, token, showTopicExplorer, topics }) => {
   const [errorMsg, setErrorMsg] = useState()
   const { snapshot, loading, updateSnapshot } = useSnapshot(
     initialSnapshot.snapshotId,
@@ -39,7 +38,7 @@ const Index = ({ resources, initialSnapshot, token, showTopicExplorer }) => {
     <>
       { showTopicExplorer &&
         <>
-          <TopicExplorer topics={topics()}/>
+          <TopicExplorer topics={topics}/>
           <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
         </>
       }
@@ -86,9 +85,10 @@ Index.getInitialProps = async ({
     const token = getTokenFromCookieHeader(headers);
     const initialSnapshot = { vulnerabilities: [], assets: [], notes: null }
     const resources = await requestResources({ token });
+    const topics = await requestPrompts({token})
     const showTopicExplorer = process.env.SHOW_TOPIC_EXPLORER;
 
-    return { resources, initialSnapshot, token, showTopicExplorer };
+    return { resources, initialSnapshot, token, showTopicExplorer, topics };
   } catch (err) {
     console.log("Failed to load initial Props:" + err)
     res.writeHead(err instanceof HttpStatusError ? err.statusCode : 500).end();

--- a/pages/snapshots/[id].js
+++ b/pages/snapshots/[id].js
@@ -1,14 +1,16 @@
 import { useState, useEffect } from 'react';
 import useSnapshot from 'lib/api/utils/useSnapshot';
-import { requestSnapshot, requestResources } from 'lib/api';
+import { requestSnapshot, requestResources, requestPrompts } from 'lib/api';
 import HttpStatusError from 'lib/api/domain/HttpStatusError';
 import { getTokenFromCookieHeader } from 'lib/utils/token';
 import { Button, TextArea } from 'components/Form';
 import VulnerabilitiesGrid from 'components/Feature/VulnerabilitiesGrid';
 import { convertIsoDateToString, convertIsoDateToYears } from 'lib/utils/date';
 import geoCoordinates from 'lib/api/utils/geoCoordinates';
+import TopicExplorer from 'components/Feature/TopicExplorer';
 
-const SnapshotSummary = ({ resources, initialSnapshot, token }) => {
+
+const SnapshotSummary = ({ resources, initialSnapshot, token , topics}) => {
   const { snapshot, loading, updateSnapshot } = useSnapshot(
     initialSnapshot.snapshotId,
     {
@@ -91,7 +93,8 @@ const SnapshotSummary = ({ resources, initialSnapshot, token }) => {
   
   return (
     <>
-      <div>      
+      <div>   
+      <TopicExplorer topics={topics}/>   
         { editSnapshot && customerId && (
           <a
           href={`${INH_URL}/help-requests/edit/${customerId}`}
@@ -223,10 +226,12 @@ SnapshotSummary.getInitialProps = async ({
     const token = getTokenFromCookieHeader(headers);
     const initialSnapshot = await requestSnapshot(id, { token });
     const resources = await requestResources({ token });
+    const topics = await requestPrompts({ token });
     return {
       resources,
       initialSnapshot,
-      token
+      token,
+      topics
     };
   } catch (err) {
     res.writeHead(err instanceof HttpStatusError ? err.statusCode : 500).end();


### PR DESCRIPTION
This pr no longer makes use of the prompts in the flat file. Instead the
prompts are being pulled from Air-table which can be easier maintained. 

**What**  
- Make use of the` getPrompts` endpoint which retrieves the prompts from air-table and populates the TopicExplorer upon search

**Why**  
- This using Air-table is easier and more accessible for the staff to maintain as compared with a flat file


![image](https://user-images.githubusercontent.com/46002877/92484719-f1823780-f1e1-11ea-996c-f7ec2b4613ac.png)
