### PR TITLE
Update conversational prompt titles

### DIFF
--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -32,20 +32,24 @@ const TopicExplorer = (props) => {
   }
   return (
     <>
-      <h1>Topics to explore</h1>
-      <div className="govuk-form-group">
-        <h2>How can we help?</h2>
+      <h1>Search for a topic</h1>
+      <div className="govuk-form-group conversational-prompt-results-spacing">
+       
+      <div id='example-search'>Try searching for keywords like{' '}
+          <button className='button-as-link govuk-!-padding-0' data-search-term='food' onClick={populateInput} data-testid='food'>food</button>,{' '}
+          <button className='button-as-link govuk-!-padding-0' data-search-term='health' onClick={populateInput}>health</button>, or{' '}
+          <button className='button-as-link govuk-!-padding-0' data-search-term='benefits'onClick={populateInput}>benefits</button>
+        </div>
+
         <input
           type="text"
           className="govuk-input govuk-input--width-20"
           value={searchTerm}
           onChange={onSearchChange}
         />
-        <div id='example-search'>Try a search for{' '}
-          <button className='button-as-link govuk-!-padding-0' data-search-term='food' onClick={populateInput} data-testid='food'>food</button>,{' '}
-          <button className='button-as-link govuk-!-padding-0' data-search-term='health' onClick={populateInput}>health</button>, or{' '}
-          <button className='button-as-link govuk-!-padding-0' data-search-term='benefits'onClick={populateInput}>benefits</button>
-        </div>
+
+
+
       </div>
 
       { searchResults.length > 0 &&

--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -33,9 +33,9 @@ const TopicExplorer = (props) => {
   return (
     <>
       <h1>Search for a topic</h1>
-      <div className="govuk-form-group conversational-prompt-results-spacing">
+      <div className="govuk-form-group govuk-!-margin-bottom-7">
        
-      <div id='example-search'>Try searching for keywords like{' '}
+      <div class="govuk-!-padding-bottom-4" id='example-search'>Try searching for keywords like{' '}
           <button className='button-as-link govuk-!-padding-0' data-search-term='food' onClick={populateInput} data-testid='food'>food</button>,{' '}
           <button className='button-as-link govuk-!-padding-0' data-search-term='health' onClick={populateInput}>health</button>, or{' '}
           <button className='button-as-link govuk-!-padding-0' data-search-term='benefits'onClick={populateInput}>benefits</button>

--- a/components/Feature/TopicExplorer/index.test.js
+++ b/components/Feature/TopicExplorer/index.test.js
@@ -8,10 +8,6 @@ describe('TopicExplorer', () => {
       render(<TopicExplorer topics={topics}/>);
     });
 
-    it('renders successfully', () => {
-      expect(screen.getByText('How can we help?')).toBeInTheDocument();
-    });
-
     it('shows no results for a search', () => {
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: 'giraffe' },

--- a/cypress/integration/features/editSnapshot.spec.js
+++ b/cypress/integration/features/editSnapshot.spec.js
@@ -57,7 +57,6 @@ context('Edit snapshot', () => {
       cy.visit(`/snapshots/1`);
 
       cy.contains('Phineas Flynn').should('be.visible')
-      cy.contains('How can we help?').should('be.visible')
       cy.contains('Things to explore with the resident').should('be.visible')
 
       cy.get('[data-testid=accordion-item]')

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -7,8 +7,7 @@ context('Index page', () => {
 
   describe('Page structure', () => {
     it('has the right headings', () => {
-      cy.contains('Topics to explore').should('be.visible')
-      cy.contains('How can we help?').should('be.visible')
+      cy.contains('Search for a topic').should('be.visible')
       cy.contains('Resource Finder').should('be.visible')
     });
 
@@ -66,10 +65,6 @@ context('Index page', () => {
   });
 
   describe("Topic Explorer", () => {
-    it("can show the topic explorer", () => {
-      cy.contains('How can we help?').should('be.visible')
-    })
-
 
     it("can show food example prompts", () => {
       cy.get("#example-search").contains('food').click();

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,7 +40,7 @@ const Index = ({ resources, initialSnapshot, token, showTopicExplorer }) => {
       { showTopicExplorer &&
         <>
           <TopicExplorer topics={topics()}/>
-          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+          <hr className="govuk-section-break hr-additional-spacing govuk-section-break--visible" />
         </>
       }
       <h1>

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -109,3 +109,20 @@ position: relative;
   cursor: pointer;
   color: #1d70b8;
 }
+
+.button-as-link:focus {
+outline:0;
+}
+
+.hr-additional-spacing {
+margin-top:60px;
+margin-bottom:50px;
+}
+
+.conversational-prompt-results-spacing {
+  margin-bottom: 40px;
+}
+
+#example-search {
+  padding-bottom:20px;
+}

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -118,11 +118,3 @@ outline:0;
 margin-top:60px;
 margin-bottom:50px;
 }
-
-.conversational-prompt-results-spacing {
-  margin-bottom: 40px;
-}
-
-#example-search {
-  padding-bottom:20px;
-}


### PR DESCRIPTION
**What**  
This update reflects the findings in the research, with title updates, a title removed, and additional spacing added
![titles switcharoo](https://user-images.githubusercontent.com/64266608/92501712-d40b9880-f1f6-11ea-8b37-6cb8349ba79e.gif)


**Why**  
To make the conversational prompt clearer for Agents to use

**Anything else?**  
I also removed the horrible black outline that appeared when clicking on the 3 suggestions, plus attempted to update the cypress tests :-)
