### PR TITLE
Update styling of listed links in conversational prompts

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -6,7 +6,7 @@ import { getTokenFromCookieHeader } from 'lib/utils/token';
 import VulnerabilitiesGrid from 'components/Feature/VulnerabilitiesGrid';
 import TopicExplorer from 'components/Feature/TopicExplorer';
 
-const Index = ({ resources, initialSnapshot, token, showTopicExplorer, topics }) => {
+const Index = ({ resources, initialSnapshot, token, showTopicExplorer, topics }) =>{
   const [errorMsg, setErrorMsg] = useState()
   const { snapshot, loading, updateSnapshot } = useSnapshot(
     initialSnapshot.snapshotId,

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -87,6 +87,27 @@ position: relative;
   margin-bottom: 25px;
 }
 
+.conv-prompt li ul {
+padding-inline-start:0px;
+padding:15px 0px 0px 0px;
+}
+
+.conv-prompt li ul li{
+  background:none;
+  padding: 0px;
+  list-style: none;
+  margin-bottom: 10px;
+  font-size: 16px !important;
+  font-size: 1rem !important;
+  line-height: 1.25 !important;
+  color: #505a5f;
+}
+
+.conv-prompt li ul li a{
+  color: #025ea6;
+  font-weight:600;
+}
+
 .conv-prompt-text {
   font-weight:600;
   margin: 0px;


### PR DESCRIPTION
**What**  
The styling made the links look out of place. The styling has been updated to make them match the rest of the design.

Because the information is being pulled in from AirTable, I had to manipulate the styling on the classes/elements that were readily available, rather than create entirely new classes.

Old:
![image](https://user-images.githubusercontent.com/64266608/92577292-66a54980-f282-11ea-84d9-83248ac51a61.png)

New:
![image](https://user-images.githubusercontent.com/64266608/92577429-889ecc00-f282-11ea-8d88-678d0901fc67.png)


**Why**  
To make the content match the rest of the design.