### PR TITLE
Fix layout breaking for expanded content

### DIFF
--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -21,7 +21,9 @@ a {
 .small {
   font-size: 1em !important;
   line-height: 1.2em !important;
+  word-break: break-word;
 }
+
 .align-horizontally {
   position: relative;
   float: left;


### PR DESCRIPTION
**What**  
This is a one-line css fix which prevents links in the expanded content from forcing wider widths.

Before:
![image](https://user-images.githubusercontent.com/64266608/92582988-973cb180-f289-11ea-9be4-ac11e63dc6db.png)

After:
![image](https://user-images.githubusercontent.com/64266608/92583031-a6bbfa80-f289-11ea-8974-b63b3cd8a3ca.png)



**Why**  
The current styling in place, allows long links to break the widths of the content areas.
