### PR TITLE
Update-Conversational-Prompts_Layout

### DIFF
--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -35,7 +35,7 @@ const TopicExplorer = (props) => {
   }
   return (
     <>
-      <h1>Search for a topic</h1>
+      <h2>Discuss a topic</h2>
       <div className="govuk-form-group govuk-!-margin-bottom-7">
        
       <div class="govuk-!-padding-bottom-4" id='example-search'>Try searching for keywords like{' '}
@@ -57,7 +57,6 @@ const TopicExplorer = (props) => {
 
       { searchResults.length > 0 &&
         <>
-          <h2>Conversational prompts</h2>
           <ul className="govuk-list conv-prompt">
             { searchResults.map((result, i) =>
               <li key={i}>

--- a/components/Form/TextArea/index.js
+++ b/components/Form/TextArea/index.js
@@ -5,15 +5,15 @@ const TextArea = ({ label, name, onChange, value }) => {
   return (
     <div className="govuk-form-group even-spacing" data-testid={name}>
       <label htmlFor={`${name}`}>
-        <h3>
+        <p>
           {label}
-        </h3>
+        </p>
       </label>
       <textarea
         className="govuk-textarea"
         id={name}
         name={name}
-        rows="5"
+        rows="4"
         onChange={updateValue}
         value={value}
       ></textarea>

--- a/cypress/integration/features/editSnapshot.spec.js
+++ b/cypress/integration/features/editSnapshot.spec.js
@@ -56,7 +56,7 @@ context('Edit snapshot', () => {
     it('Displays editable snapshot if there are no assets, vulnerabilites and notes added', () => {
       cy.visit(`/snapshots/1`);
 
-      cy.contains('Phineas Flynn').should('be.visible')
+      cy.contains(`Phineas's resources`).should('be.visible')
 
 
       cy.get('[data-testid=accordion-item]')

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -7,12 +7,12 @@ context('Index page', () => {
 
   describe('Page structure', () => {
     it('has the right headings', () => {
-      cy.contains('Search for a topic').should('be.visible')
-      cy.contains('Resource Finder').should('be.visible')
+      cy.contains('Discuss a topic').should('be.visible')
+      cy.contains('Resources for residents').should('be.visible')
     });
 
     it('has no content outside top-level headings', () => {
-      cy.checkA11y('#content > h1', null, cy.terminalLog);
+      cy.checkA11y('#content > h2', null, cy.terminalLog);
     });
   });
 

--- a/cypress/integration/pages/snapshotSummary.spec.js
+++ b/cypress/integration/pages/snapshotSummary.spec.js
@@ -49,7 +49,9 @@ context('Snapshot summary', () => {
     it('Displays a read only view of a snapshot', () => {
       cy.visit(`/snapshots/2`);
 
-      cy.get('h2').should('contain', 'Ferb Flynn');
+      cy.get('h1').should('contain', `Ferb's resources`);
+
+      cy.get('#example-search').should('not.exist');
 
       cy.get('[data-testid=age-and-date-of-birth]').should(
         'contain',
@@ -82,7 +84,7 @@ context('Snapshot summary', () => {
     it('Displays none captured if there are no vulnerabilities or assets', () => {
       cy.visit(`/snapshots/3`);
 
-      cy.get('h2').should('contain', 'Candace Flynn');
+      cy.get('h1').should('contain', `Candace's resources`);
 
       cy.get('[data-testid=vulnerabilities-summary]')
         .should('contain', 'Vulnerabilities')

--- a/pages/index.js
+++ b/pages/index.js
@@ -39,12 +39,12 @@ const Index = ({ resources, initialSnapshot, token, showTopicExplorer, topics })
       { showTopicExplorer &&
         <>
           <TopicExplorer topics={topics}/>
-          <hr className="govuk-section-break hr-additional-spacing govuk-section-break--visible" />
+          <hr className="govuk-section-break hr-additional-spacing" />
         </>
       }
-      <h1>
-        Resource Finder
-      </h1>
+      <h2>
+      Resources for residents
+      </h2>
       <p>
       Enter a postcode to help filter the results by distance:
       </p>

--- a/pages/snapshots/[id].js
+++ b/pages/snapshots/[id].js
@@ -106,12 +106,18 @@ const SnapshotSummary = ({ resources, initialSnapshot, token, topics, showTopicE
 
         )}
       </div>
-      <h1>Recommended resources</h1>
+      <h1 class="no-bottom-margin">{firstName}'s resources</h1>
       <div class="summary-sections">
-      <h2 class="summary-titles">
-        {firstName} {lastName}
-      </h2>
-      Postcode: {postcode}
+      
+      {editSnapshot && (
+        <>
+          <TextArea
+            name="notes"
+            label="What prompted the Resident to get in touch today?"
+            onChange={updateNotes}
+          />
+</>
+      )}
       </div>
 
     
@@ -123,19 +129,17 @@ const SnapshotSummary = ({ resources, initialSnapshot, token, topics, showTopicE
           Aged {convertIsoDateToYears(dob)} ({convertIsoDateToString(dob)})
         </span>
       )}
-      { showTopicExplorer &&
+      { editSnapshot &&
         <>
           <TopicExplorer topics={topics}/>
-          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+          <hr className="govuk-section-break hr-additional-spacing" />
         </>
       }
       {editSnapshot && (
         <>
-          <TextArea
-            name="notes"
-            label="What prompted the Resident to get in touch today?"
-            onChange={updateNotes}
-          />
+
+          <h2>Resources for residents</h2>
+          Resident's postcode: {postcode}
 
           <VulnerabilitiesGrid
             onError={handleError}
@@ -160,6 +164,7 @@ const SnapshotSummary = ({ resources, initialSnapshot, token, topics, showTopicE
       {!editSnapshot && (
         <>
           <div class="summary-sections" data-testid="notes-summary">
+          <h3 class="summary-titles">What prompted the Resident to get in touch today?</h3>
             {notes ? notes : 'Nothing captured'}
           </div>
 

--- a/pages/snapshots/[id].test.js
+++ b/pages/snapshots/[id].test.js
@@ -43,7 +43,7 @@ describe('SnapshotSummary', () => {
         <SnapshotSummary initialSnapshot={snapshot} resources={resources} />
       );
       expect(
-        getByText(`${snapshot.firstName} ${snapshot.lastName}`)
+        getByText(`${snapshot.firstName}'s resources`)
       ).toBeInTheDocument();
     });
 

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -175,8 +175,9 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   h2 {
-    font-size: 30px;
-    font-size: 1.875rem;
+    font-size: 36px;
+    font-size: 2.3em;
+    margin-block-end: 10px;
     line-height: 36px;
     line-height: 2.25rem;
   }
@@ -190,6 +191,10 @@ h1, h2, h3, h4, h5, h6 {
 
 }
 
+.no-bottom-margin {
+  margin-block-end: 0;
+  }
+
 .button-as-link:focus {
 outline:0;
 }
@@ -197,4 +202,5 @@ outline:0;
 .hr-additional-spacing {
 margin-top:60px;
 margin-bottom:50px;
+border-bottom: 0px solid;
 }


### PR DESCRIPTION
**What**  
This update adjusts the layout of the conversational prompts tool, as well as prevents it from appearing in the middle of the summary page.
![image](https://user-images.githubusercontent.com/64266608/92610565-bc441b00-f2af-11ea-81e2-a9e09c1cca03.png)


**Why**  
To make the tool more usable for Agents, as there was some confusion as to what each tool does and how they should be used.

**Anything else?**  
This update also prevents the Topics Search tool from appearing in the middle of the summary page
![image](https://user-images.githubusercontent.com/64266608/92610494-a8001e00-f2af-11ea-83f4-b8321488b646.png)

