### PR TITLE
add-padding-to-improve-spacing

### DIFF
--- a/components/Feature/VulnerabilitiesGrid/index.js
+++ b/components/Feature/VulnerabilitiesGrid/index.js
@@ -316,7 +316,7 @@ const VulnerabilitiesGrid = ({ resources, onUpdate, residentCoordinates, generic
                   </div>
                 </div>
 
-                <div className="govuk-grid-column-full-width">
+                <div className="govuk-grid-column-full-width govuk-!-padding-top-5">
                   {
                     <div key={`${id}-resources`}>
                       {expandedGroups[id] &&

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -72,13 +72,14 @@ position: relative;
   margin-bottom: 10px;
 }
 
-.ResourceCard_tags {
+.ResourceCard_tags__1Zgh3 {
   float:left;
   margin-bottom: 5px;
 }
 
-.conv-prompt {
-  padding-right:150px;
+.ResourceCard_resource__-Szc9 .ResourceCard_tags__container__3A8cx {
+  margin-bottom: 0px;
+  display: inherit;
 }
 
 .conv-prompt li {
@@ -87,6 +88,10 @@ position: relative;
   list-style: none;
   margin-bottom: 25px;
 }
+
+.conv-prompt {
+  padding-right:150px;
+  }
 
 .conv-prompt li ul {
 padding-inline-start:0px;

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -72,14 +72,13 @@ position: relative;
   margin-bottom: 10px;
 }
 
-.ResourceCard_tags__1Zgh3 {
+.ResourceCard_tags {
   float:left;
   margin-bottom: 5px;
 }
 
-.ResourceCard_resource__-Szc9 .ResourceCard_tags__container__3A8cx {
-  margin-bottom: 0px;
-  display: inherit;
+.conv-prompt {
+  padding-right:150px;
 }
 
 .conv-prompt li {


### PR DESCRIPTION
**What**  
Spacing between the resources and filters has been increased, padding to the right of the prompts has been added to reduce long line lengths
![image](https://user-images.githubusercontent.com/64266608/92716706-14822800-f357-11ea-83d9-940068ec9c6c.png)
![image](https://user-images.githubusercontent.com/64266608/92716763-25cb3480-f357-11ea-8838-ff640f6ee7f4.png)

**Why**  
To improve legibility
