### PR TITLE
fix-incorrect-link-colours

### DIFF
--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -114,6 +114,14 @@ padding:15px 0px 0px 0px;
   font-weight:600;
 }
 
+.conv-prompt li a{
+  color: #025ea6;
+  font-weight:600;
+  font-size: 16px !important;
+  font-size: 1rem !important;
+  line-height: 1.25 !important;
+}
+
 .conv-prompt-text {
   font-weight:600;
   margin: 0px;


### PR DESCRIPTION
**What**  
Some conversational prompts are displaying the wrong styling on links
![image](https://user-images.githubusercontent.com/64266608/92719269-d1c24f00-f35a-11ea-8bc1-14ea72b0c7d5.png)


**Why**  
For consistency