### PR TITLE
update-feedback-link

### DIFF
--- a/components/Layout/PhaseBanner/index.js
+++ b/components/Layout/PhaseBanner/index.js
@@ -6,7 +6,7 @@ const PhaseBanner = ({ phase, feedbackUrl }) => (
       </strong>
       <span className="govuk-phase-banner__text">
         This is a new service – your{' '}
-        <a className="govuk-link" href={feedbackUrl}>
+        <a className="govuk-link" href={feedbackUrl} target="_blank">
           feedback
         </a>{' '}
         will help us to improve it.

--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -13,7 +13,7 @@ const Layout = ({ children }) => (
     <div className="govuk-width-container app-width-container">
       <PhaseBanner
         phase="alpha"
-        feedbackUrl="https://forms.gle/B6vEMgp7sCsjJqNdA"
+        feedbackUrl="https://forms.gle/zAqXMUabo1oMfzDL7"
       />
       <main
         className="govuk-main-wrapper app-main-class"


### PR DESCRIPTION
**What**  
This update changes the feedback link in the ALPHA banner at the top, and forces the link to open in a new browser tab.

There were no **visual changes**.

**Why**  
A simpler form will allow for quick feedback.