### PR TITLE
Remove default dropdown from search

### DIFF
--- a/components/Feature/TopicExplorer/index.js
+++ b/components/Feature/TopicExplorer/index.js
@@ -77,7 +77,7 @@ const TopicExplorer = (props) => {
           autoComplete="off"
         />
         <datalist id="input-tags">
-          {
+          {searchTerm &&
             tags.sort().map((t,i) => (
               <option key={i}>{t}</option>
             ))

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -82,6 +82,16 @@ context('Index page', () => {
       cy.get('input').should('have.value', 'benefits')
     })
 
+
+    it("does not show search options when there is no text in the input", () => {
+      cy.get('#text-input').click()
+      cy.get('option').should('not.exist')
+    })
+
+    it("does show search options when there is text in the input", () => {
+      cy.get('#text-input').type('a')
+      cy.get('option').should('exist')
+    })
   })
 
 });


### PR DESCRIPTION
**What**  
The search was displaying the dropdown search options as soon as the user clicked on the search. This pr only displays search options when the user has typed something in the search box.

**Why**  
Allows users to use the search as it was intended and not as a dropdown.

![image](https://user-images.githubusercontent.com/46002877/92894712-bb77ca00-f412-11ea-9551-65f04a406f58.png)
