### PR TITLE
Remove dynamically rendered react classes from stylesheet

### DIFF
--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -30,7 +30,7 @@ const ResourceCard = ({
   const selfReferralElement = (selfReferral == 'No') ? 'Referral required' : 'Self referral'
   const websiteElement = websites && websites.length > 0 &&  websites.map(website => (<a href={websites[0]} target="_blank" rel="noopener noreferrer">{websites[0]}</a>))
   const distributionElement =  tags.filter(t => HIDDEN_TAGS.includes(t)).join(", ")
-  const tagsElement = tags.filter(t => !HIDDEN_TAGS.includes(t)).map(item=> (<span key={"tags-"+item} className={css.tags}>{trimLength(item, 20)}</span>))
+  const tagsElement = tags.filter(t => !HIDDEN_TAGS.includes(t)).map(item=> (<span key={"tags-"+item} className={`${css.tags} tag-element`}>{trimLength(item, 20)}</span>))
   const snapshot = (customerId != undefined) ? true : false
   const summaryDataExists = ( telephone  || distance != 100 || currentProvision || openingTimes)
   const marginClass = (summaryDataExists) ? "" : "remove-margin-bottom"
@@ -51,7 +51,7 @@ const ResourceCard = ({
 
   return (
     <div className={`resource ${css.resource}`} {...others}>
-      <div className={css.tags__container}>
+      <div className={`${css.tags__container} card-header-tag`}>
         {tagsElement}
       </div>
        <h3 className={marginClass}>{name}</h3>

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -72,12 +72,12 @@ position: relative;
   margin-bottom: 10px;
 }
 
-.ResourceCard_tags__1Zgh3 {
+.tag-element {
   float:left;
   margin-bottom: 5px;
 }
 
-.ResourceCard_resource__-Szc9 .ResourceCard_tags__container__3A8cx {
+.card-header-tag {
   margin-bottom: 0px;
   display: inherit;
 }


### PR DESCRIPTION
**What**  
Some styling rules for cards were introduced, but they're targeted at classes that are the result of dynamic React rendering.

**Why**  
These'll be different for each card (and may not be deterministic), so not all cards will be correctly styled.
