### PR TITLE
Redirect to hard-coded path after signing in

### DIFF
--- a/pages/loggedout/index.js
+++ b/pages/loggedout/index.js
@@ -1,5 +1,6 @@
 export default function LoggedOut() {
-  const returnUrl = "https://auth.hackney.gov.uk/auth?redirect_uri=" + process.env.NEXT_PUBLIC_URL
+  const hardCodedPath = "https://frontdoor-snapshot-staging.hackney.gov.uk/"
+  const returnUrl = "https://auth.hackney.gov.uk/auth?redirect_uri=" + hardCodedPath
 
   return (
     <>

--- a/pages/loggedout/index.js
+++ b/pages/loggedout/index.js
@@ -5,8 +5,8 @@ export default function LoggedOut() {
   return (
     <>
       <h1 className='govuk-heading-l'>You need permission to access this service</h1>
-      <p className='govuk-body'><a href={returnUrl} className='govuk-link'>Log in to your Hackney account.</a></p>
-      <p className='govuk-body'>If you're already logged in, contact Chris Caden to get access (christopher.caden@hackney.gov.uk).</p>
+      <p className='govuk-body'><a href={returnUrl} className='govuk-link'>Sign in to your Hackney account.</a></p>
+      <p className='govuk-body'>If you're already signed in, contact Chris Caden to get access (christopher.caden@hackney.gov.uk).</p>
     </>
   );
 }


### PR DESCRIPTION
`NEXT_PUBLIC_URL` is returning undefined for a reason that's eluding me - I suspect it's that this env var isn't available client-side, but I haven't been able to resolve it in the time available.

This commit risks someone being directed to a live environment accidentally upon logging in, but I think it is worth the tradeoff for
users not getting stuck/confused after they login.

I also took the liberty of tweaking the language slightly - from talking about "logging in" to "signing in" instead.