### PR TITLE
Use _document tag for Google Analytics tracking code

### DIFF
--- a/components/CookieBanner/index.js
+++ b/components/CookieBanner/index.js
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import cookie from 'cookie';
 import moment from 'moment';
-import TagManager from 'react-gtm-module';
 import css from './index.module.scss';
 
 const cookieNames = {
@@ -33,16 +32,8 @@ const CookieBanner = () => {
     }
   };
 
-  const initTagManager = () => {
-    console.log('init tag manager');
-    TagManager.initialize({
-      gtmId: process.env.NEXT_PUBLIC_GTM_ID
-    });
-  };
-
   const handleOptIn = useCallback(() => {
     setCookies(true);
-    initTagManager();
   });
 
   const handleOptOut = useCallback(() => {
@@ -56,9 +47,7 @@ const CookieBanner = () => {
     const hasCookieOptIn = cookies[cookieNames.optedIn] === 'true';
 
     if (hasReadMessage) {
-      if (hasCookieOptIn) {
-        initTagManager();
-      } else {
+      if (!hasCookieOptIn) {
         deleteCookies();
       }
     } else {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "node-lambda-authorizer": "https://github.com/LBHackney-IT/node-lambda-authorizer.git#0fe9e75",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "react-gtm-module": "^2.0.8",
     "restana": "^4.3.4",
     "serve-static": "^1.14.1",
     "serverless-http": "^2.4.1",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -6,16 +6,32 @@ export default class AppDocument extends Document {
     return (
       <Html className="govuk-template lbh-template">
         <Head>
-        <script dangerouslySetInnerHTML={{ __html: `
+          <script dangerouslySetInnerHTML={{ __html: `
             (function(h,o,t,j,a,r){
-                h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-                h._hjSettings={hjid:${process.env.HOTJAR_ID},hjsv:6};
-                a=o.getElementsByTagName('head')[0];
-                r=o.createElement('script');r.async=1;
-                r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-                a.appendChild(r);
-            })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-            `}} />
+              h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+              h._hjSettings={hjid:${process.env.HOTJAR_ID},hjsv:6};
+              a=o.getElementsByTagName('head')[0];
+              r=o.createElement('script');r.async=1;
+              r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+              a.appendChild(r);
+             })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+          `}} />
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GTM_ID}`}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${process.env.NEXT_PUBLIC_GTM_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+            }}
+          />
         </Head>
         <body className="govuk-template__body lbh-template__body js-enabled">
           <Main />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9488,11 +9488,6 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-gtm-module@^2.0.8:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.10.tgz#462296c3d622b82413d0917d430bec557a586237"
-  integrity sha512-7fRxphVxbJVCNWDQyegugZOrOw97vqwzbTSZlHM2n+otg2iBQvKa0SzFxwcLi9monXADjWGX6xQER6IOl75FPw==
-
 react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Retrieved from the implementation at https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics.

This commit also removes the existing tag manager code, which wasn't working with Hackney's current GA setup.