### PR TITLE
Set base url env var in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,8 @@ jobs:
         type: env_var_name
       AWS_CERTIFICATE_ARN:
         type: string
+      URL:
+        type: string
     steps:
       - *attach_workspace
       - checkout
@@ -131,6 +133,7 @@ jobs:
             export NEXT_PUBLIC_SINGLEVIEW_URL=<< parameters.SINGLEVIEW_URL >>
             export INH_URL=<< parameters.INH_URL >>
             export AWS_CERTIFICATE_ARN=<< parameters.AWS_CERTIFICATE_ARN >>
+            export NEXT_PUBLIC_URL=<< parameters.URL >>
             yarn
             yarn build
             yarn --production=true
@@ -158,6 +161,7 @@ workflows:
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_STAGING}
           INH_URL: ${INH_URL_STAGING}
+          URL: ${NEXT_PUBLIC_URL_STAGING}
           filters:
             branches:
               only: master
@@ -184,5 +188,6 @@ workflows:
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_PRODUCTION}
           INH_URL: ${INH_URL_PRODUCTION}
+          URL: ${NEXT_PUBLIC_URL_PRODUCTION}
           requires:
             - assume-role-production


### PR DESCRIPTION
**What**  
Set base url env var in circleCI

**Why**  
It's not currently being picked up because it needs to be set in the build stage
