### PR TITLE
Filter accordion items to only display categories that contain services

### DIFF
--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -5,22 +5,25 @@ import { Accordion, AccordionItem } from 'components/Form';
 const Services = ({ resources, taxonomies }) => {
   const [expandedGroups, setExpandedGroups] = useState({});
 
-  taxonomies.forEach(
-    taxonomy =>
-      (taxonomy.resources = resources
-        .map(resource => {
-          if (taxonomy.name == resource.categoryName) return resource;
-        })
-        .filter(x => x))
+  const taxonomiesToRender = taxonomies.filter(taxonomy =>
+    resources.some(resource => resource.categoryName === taxonomy.name)
   );
+
+  taxonomiesToRender.forEach(
+    taxonomy =>
+      (taxonomy.resources = resources.filter(
+        resource => taxonomy.name == resource.categoryName
+      ))
+  );
+
   return (
     <>
       <div className="govuk-grid-column-full-width">
         <Accordion title="">
-          {taxonomies.map(taxonomy => {
+          {taxonomiesToRender.map(taxonomy => {
             return (
               <>
-                {taxonomy.resources.length > 0 && (
+                {
                   <AccordionItem
                     key={`taxonomy-${taxonomy.id}`}
                     id={taxonomy.id}
@@ -44,7 +47,7 @@ const Services = ({ resources, taxonomies }) => {
                       />
                     ))}
                   </AccordionItem>
-                )}
+                }
               </>
             );
           })}

--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -1,48 +1,50 @@
 import { useState } from 'react';
 import ResourceCard from 'components/Feature/VulnerabilitiesGrid/ResourceCard';
-import {
-  Accordion,
-  AccordionItem
-} from 'components/Form';
+import { Accordion, AccordionItem } from 'components/Form';
 
 const Services = ({ resources, taxonomies }) => {
   const [expandedGroups, setExpandedGroups] = useState({});
 
+  taxonomies.forEach(
+    taxonomy =>
+      (taxonomy.resources = resources
+        .map(resource => {
+          if (taxonomy.name == resource.categoryName) return resource;
+        })
+        .filter(x => x))
+  );
   return (
     <>
       <div className="govuk-grid-column-full-width">
-        <Accordion
-          title=""
-        >
+        <Accordion title="">
           {taxonomies.map(taxonomy => {
             return (
               <>
-                <AccordionItem
-                  key={`taxonomy-${taxonomy.id}`}
-                  id={taxonomy.id}
-                  heading={taxonomy.name}
-                  onClick={expanded =>
-                    setExpandedGroups({
-                      ...expandedGroups,
-                      [taxonomy.id]:
-                        expandedGroups[taxonomy.id] !== undefined
-                          ? !expandedGroups[taxonomy.id]
-                          : expanded
-                    })
-                  }
-                >
-                  {resources.map(
-                    resource =>
-                      taxonomy.name == resource.categoryName && (
-                        <ResourceCard
-                          key={`resource-card-${resource.id}-${resource.name}`}
-                          data-testid={`resource-${resource.id}`}
-                          {...resource}
-                          updateSelectedResources={() => {}}
-                        />
-                      )
-                  )}
-                </AccordionItem>
+                {taxonomy.resources.length > 0 && (
+                  <AccordionItem
+                    key={`taxonomy-${taxonomy.id}`}
+                    id={taxonomy.id}
+                    heading={taxonomy.name}
+                    onClick={expanded =>
+                      setExpandedGroups({
+                        ...expandedGroups,
+                        [taxonomy.id]:
+                          expandedGroups[taxonomy.id] !== undefined
+                            ? !expandedGroups[taxonomy.id]
+                            : expanded
+                      })
+                    }
+                  >
+                    {taxonomy.resources.map(resource => (
+                      <ResourceCard
+                        key={`resource-card-${resource.id}-${resource.name}`}
+                        data-testid={`resource-${resource.id}`}
+                        {...resource}
+                        updateSelectedResources={() => {}}
+                      />
+                    ))}
+                  </AccordionItem>
+                )}
               </>
             );
           })}

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -22,7 +22,6 @@ context('Index page', () => {
         .should('contain', 'First category')
         .and('contain', 'Second category')
         .and('contain', 'Third category')
-        .and('contain', 'Fourth category');
     });
 
     it('Displays the resources', () => {

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -21,7 +21,11 @@ context('Index page', () => {
       cy.get('[data-testid=accordion-item]')
         .should('contain', 'First category')
         .and('contain', 'Second category')
-        .and('contain', 'Third category')
+        .and('contain', 'Third category');
+      cy.get('[data-testid=accordion-item]').should(
+        'not.contain',
+        'Fourth category'
+      );
     });
 
     it('Displays the resources', () => {


### PR DESCRIPTION
**What**  
Only display categories that have services associated with them:
Before:
<img width="589" alt="image" src="https://user-images.githubusercontent.com/54268893/110318309-3c500100-8005-11eb-9e9a-1ab2432c018a.png">
After:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/54268893/110318342-440fa580-8005-11eb-9730-03ab4b9195a7.png">

**Why**  
To remove irrelevant headings for empty categories
