### PR TITLE
Remove some unused fields from resource card

### DIFF
--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -1,6 +1,5 @@
 import css from './index.module.scss';
 import SummaryList from 'components/Form/SummaryList';
-import { useState } from 'react';
 
 const HIDDEN_TAGS = ['Delivery', 'Collection', 'Food'] 
 
@@ -14,12 +13,9 @@ const ResourceCard = ({
   postcode,
   tags,
   telephone,
-  openingTimes,
-  currentProvision,
   email,
   referralContact,
   referralWebsite,
-  selfReferral,
   notes,
   distance,
   matches,
@@ -31,13 +27,10 @@ const ResourceCard = ({
 }) => {
   const trimLength = (s, length) => s.length > length ? s.substring(0, length) + "..." : s
 
-  const selfReferralElement = (selfReferral == 'No') ? 'Referral required' : 'Self referral'
   const websiteElement = websites && websites.length > 0 &&  websites.map(website => (<div><a href={website} target="_blank" rel="noopener noreferrer">{website}</a></div>))
   const distributionElement =  tags.filter(t => HIDDEN_TAGS.includes(t)).join(", ")
   const tagsElement = tags.filter(t => !HIDDEN_TAGS.includes(t)).map(item=> (<span key={"tags-"+item} className={`${css.tags} tag-element ${css[`${item}-tag`]}`}>{trimLength(item, 20)}</span>))
   const snapshot = (customerId != undefined) ? true : false
-  const summaryDataExists = ( telephone  || distance != 100 || currentProvision || openingTimes)
-  const marginClass = (summaryDataExists) ? "" : "remove-margin-bottom"
   const updateResource = () =>{
     updateSelectedResources({
       name:name,
@@ -46,8 +39,6 @@ const ResourceCard = ({
       telephone: telephone,
       email:email,
       referralContact: referralContact,
-      selfReferral: selfReferral,
-      openingTimes: openingTimes,
       websites:websites,
       notes:notes
     })
@@ -58,18 +49,17 @@ const ResourceCard = ({
       <div className={`${css.tags__container} card-header-tag`} data-testid='resource-card-tags'>
         {tagsElement}
       </div>
-       <h3 className={marginClass}>{name}</h3>
+       <h3>{name}</h3>
         <>
         <SummaryList key={`resourceInfo-${id}-${categoryId}`} name={['resourceInfo']} entries={{ 'Distance': (distance && distance < 100) ? distance + ' miles' : null ,
-      'Availability': currentProvision, 'Days / Times' : openingTimes, 'Distribution' : distributionElement, 'Telephone' : telephone, 'Service Description': serviceDescription}} customStyle="small" />
+      'Distribution' : distributionElement, 'Telephone' : telephone, 'Service Description': serviceDescription}} customStyle="small" />
 
         </>
       
       <details className="govuk-details" data-module="govuk-details">
         <summary id ={`summary-${id}`} className="">View more information</summary>
 
-        <SummaryList key={`moreResourceInfo-${id}-${categoryId}`} name={'moreResourceInfo'} entries={{ 'How to contact': selfReferralElement,
-      'Address': address, 'Description' : description, 'Website' : websiteElement, 'Additional notes' : notes, 
+        <SummaryList key={`moreResourceInfo-${id}-${categoryId}`} name={'moreResourceInfo'} entries={{'Address': address, 'Description' : description, 'Website' : websiteElement, 'Additional notes' : notes, 
       'Referral email': referralContact, 'Referral Website': referralWebsite }} customStyle="small" />
         { snapshot &&
       ( 


### PR DESCRIPTION
**What**  
Remove how to contact row from resource card as it would always default to 'self referral'
Remove opening times and current provision rows from resource card as we don't get that data from anywhere.
**Before:**
<img width="356" alt="image" src="https://user-images.githubusercontent.com/54268893/111154594-4b95f800-858b-11eb-90f2-321c75ac6d8b.png">

**After:**
<img width="329" alt="image" src="https://user-images.githubusercontent.com/54268893/111154551-3de07280-858b-11eb-952e-f468f5e7352e.png">
