### PR TITLE
Copy services to clipboard

### DIFF
--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -1,6 +1,5 @@
 import css from './index.module.scss';
 import SummaryList from 'components/Form/SummaryList';
-import { useState } from 'react';
 
 const HIDDEN_TAGS = ['Delivery', 'Collection', 'Food'] 
 
@@ -53,15 +52,12 @@ const ResourceCard = ({
     })
   }
   
-  const [copiedToClipboard, setCopiedToClipboard] = useState(false);
-  
   const copyToClipboard = () => {
     var copyText = document.getElementById(`resource-${name}`);
     copyText.hidden = false;
     copyText.select();
     copyText.setSelectionRange(0, 99999);
     document.execCommand("copy");
-    setCopiedToClipboard(true)
     copyText.hidden = true;
   }
   
@@ -82,13 +78,12 @@ const ResourceCard = ({
       </div>
       <textarea id={`resource-${name}`} type="hidden" value={clipboardServiceDetails} hidden/>
       <div>
-      <a href="javascript:void(0)" onClick={() => copyToClipboard()}>{!copiedToClipboard && <span> Copy service details</span>} {copiedToClipboard && <span> Copied to clipboard</span>}
-        <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24">
+    </div>
+      <h3 className={marginClass}>{name} <a title="copy" href="javascript:void(0)" onClick={() => copyToClipboard()}>
+        <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="24">
           <path d="M0 0h24v24H0z" fill="none"/>
           <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
-        </svg></a>
-    </div>
-      <h3 className={marginClass}>{name}</h3>
+        </svg></a></h3>
         <>
         <SummaryList key={`resourceInfo-${id}-${categoryId}`} name={['resourceInfo']} entries={{ 'Distance': (distance && distance < 100) ? distance + ' miles' : null ,
       'Availability': currentProvision, 'Days / Times' : openingTimes, 'Distribution' : distributionElement, 'Telephone' : telephone, 'Service Description': serviceDescription}} customStyle="small" />

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -65,24 +65,20 @@ const ResourceCard = ({
     // copyText.type = 'hidden';
   }
   
-  const clipboardServiceDetails = `Service Name: ${name}\n 
-                                   Telephone: ${telephone}\n 
-                                   Service Description: ${serviceDescription}\n
-                                   Address: ${address}\n
-                                   Description: ${description}\n
-                                   Website: ${websiteElement}` 
+  const clipboardServiceDetails = 
+  "Service Name: " + name + 
+      "\nTelephone: " + telephone + 
+      "\nService Description: " + serviceDescription + 
+      "\nAddress: " + address + 
+      "\nDescription: " + description + 
+      "\nWebsites: " + JSON.stringify(websites).replace("[", "").replace("]", "") 
 
   return (
     <div className={`resource ${css.resource}`} {...others}>
       <div className={`${css.tags__container} card-header-tag`} data-testid='resource-card-tags'>
         {tagsElement}
       </div>
-      <input id={`resource-${name}`} type="text" value={`Service Name: ${name}\n
-      Telephone: ${telephone}\n
-      Service Description: ${serviceDescription}\n
-      Address: ${address}\n
-      Description: ${description}\n
-      Website: ${websiteElement}`}/>
+      <textarea id={`resource-${name}`} type="text" value={clipboardServiceDetails}/>
       <div>
       <a onClick={() => copyToClipboard()}>{!copiedToClipboard && <span> Copy service details</span>} {copiedToClipboard && <span> Copied to clipboard</span>}
         <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24">

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -67,13 +67,13 @@ const ResourceCard = ({
   
   const clipboardServiceDetails = 
   "Service Name: " + name + 
-      "\nTelephone: " + telephone + 
-      "\nService Description: " + serviceDescription + 
-      "\nAddress: " + address + 
-      "\nDescription: " + description + 
-      "\nWebsites: " + JSON.stringify(websites).replace("[", "").replace("]", "") +
-      "\nReferral website: " + referralWebsite +
-      "\nReferral email: " + referralContact 
+      (telephone ? "\nTelephone: " + telephone: "") + 
+      (serviceDescription ? "\nService Description: " + serviceDescription : "") + 
+      (address ? "\nAddress: " + address: "") + 
+      (description ? "\nDescription: " + description : "") + 
+      (websites.length > 0 ? "\nWebsites: " + JSON.stringify(websites).replace("[", "").replace("]", "") : "") +
+      (referralWebsite ? "\nReferral website: " + referralWebsite : "") +
+      (referralContact ? "\nReferral email: " + referralContact : "") 
 
   return (
     <div className={`resource ${css.resource}`} {...others}>

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -82,7 +82,7 @@ const ResourceCard = ({
       </div>
       <textarea id={`resource-${name}`} type="hidden" value={clipboardServiceDetails} hidden/>
       <div>
-      <a onClick={() => copyToClipboard()}>{!copiedToClipboard && <span> Copy service details</span>} {copiedToClipboard && <span> Copied to clipboard</span>}
+      <a href="javascript:void(0)" onClick={() => copyToClipboard()}>{!copiedToClipboard && <span> Copy service details</span>} {copiedToClipboard && <span> Copied to clipboard</span>}
         <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24">
           <path d="M0 0h24v24H0z" fill="none"/>
           <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -57,12 +57,12 @@ const ResourceCard = ({
   
   const copyToClipboard = () => {
     var copyText = document.getElementById(`resource-${name}`);
-    // copyText.type = 'text';
+    copyText.hidden = false;
     copyText.select();
     copyText.setSelectionRange(0, 99999);
     document.execCommand("copy");
     setCopiedToClipboard(true)
-    // copyText.type = 'hidden';
+    copyText.hidden = true;
   }
   
   const clipboardServiceDetails = 
@@ -71,14 +71,16 @@ const ResourceCard = ({
       "\nService Description: " + serviceDescription + 
       "\nAddress: " + address + 
       "\nDescription: " + description + 
-      "\nWebsites: " + JSON.stringify(websites).replace("[", "").replace("]", "") 
+      "\nWebsites: " + JSON.stringify(websites).replace("[", "").replace("]", "") +
+      "\nReferral website: " + referralWebsite +
+      "\nReferral email: " + referralContact 
 
   return (
     <div className={`resource ${css.resource}`} {...others}>
       <div className={`${css.tags__container} card-header-tag`} data-testid='resource-card-tags'>
         {tagsElement}
       </div>
-      <textarea id={`resource-${name}`} type="text" value={clipboardServiceDetails}/>
+      <textarea id={`resource-${name}`} type="hidden" value={clipboardServiceDetails} hidden/>
       <div>
       <a onClick={() => copyToClipboard()}>{!copiedToClipboard && <span> Copy service details</span>} {copiedToClipboard && <span> Copied to clipboard</span>}
         <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24">

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -52,13 +52,45 @@ const ResourceCard = ({
       notes:notes
     })
   }
+  
+  const [copiedToClipboard, setCopiedToClipboard] = useState(false);
+  
+  const copyToClipboard = () => {
+    var copyText = document.getElementById(`resource-${name}`);
+    // copyText.type = 'text';
+    copyText.select();
+    copyText.setSelectionRange(0, 99999);
+    document.execCommand("copy");
+    setCopiedToClipboard(true)
+    // copyText.type = 'hidden';
+  }
+  
+  const clipboardServiceDetails = `Service Name: ${name}\n 
+                                   Telephone: ${telephone}\n 
+                                   Service Description: ${serviceDescription}\n
+                                   Address: ${address}\n
+                                   Description: ${description}\n
+                                   Website: ${websiteElement}` 
 
   return (
     <div className={`resource ${css.resource}`} {...others}>
       <div className={`${css.tags__container} card-header-tag`} data-testid='resource-card-tags'>
         {tagsElement}
       </div>
-       <h3 className={marginClass}>{name}</h3>
+      <input id={`resource-${name}`} type="text" value={`Service Name: ${name}\n
+      Telephone: ${telephone}\n
+      Service Description: ${serviceDescription}\n
+      Address: ${address}\n
+      Description: ${description}\n
+      Website: ${websiteElement}`}/>
+      <div>
+      <a onClick={() => copyToClipboard()}>{!copiedToClipboard && <span> Copy service details</span>} {copiedToClipboard && <span> Copied to clipboard</span>}
+        <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24">
+          <path d="M0 0h24v24H0z" fill="none"/>
+          <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+        </svg></a>
+    </div>
+      <h3 className={marginClass}>{name}</h3>
         <>
         <SummaryList key={`resourceInfo-${id}-${categoryId}`} name={['resourceInfo']} entries={{ 'Distance': (distance && distance < 100) ? distance + ' miles' : null ,
       'Availability': currentProvision, 'Days / Times' : openingTimes, 'Distribution' : distributionElement, 'Telephone' : telephone, 'Service Description': serviceDescription}} customStyle="small" />


### PR DESCRIPTION
Co-authored-by: kosiakatrina <katrina@madetech.com>

**What**  
- add copy icon next to each service name

**Why**  
- to enable users to copy all service details to clipboard (see format below)

**Copy format**
```
Service Name: <>
Telephone: 88888888
Service Description: <general description>
Address: <address>
Description: <wider description>
Websites: <website>
Referral email: <email>
Referral website: <referral website>
```

**Link to ticket**
https://trello.com/c/JUef2YQv/122-as-a-hth-frontline-worker-i-need-to-send-residents-information-about-services-so-that-they-can-refer-themselves


