### PR TITLE
Success message

### DIFF
--- a/components/Feature/ResidentDetailsForm/index.js
+++ b/components/Feature/ResidentDetailsForm/index.js
@@ -6,7 +6,8 @@ const ResidentDetailsForm = ({
   residentInfoCallback,
   token,
   showResidentForm,
-  setShowResidentForm
+  setShowResidentForm,
+  setReferralCompletion
 }) => {
   const { createReferral } = useReferral({ token });
   const [residentInfo, setResidentInfo] = useState({
@@ -36,8 +37,9 @@ const ResidentDetailsForm = ({
     setValidationError({ [value]: true, ...validationError });
   };
 
-  const onSubmitForm = e => {
+  const onSubmitForm = async e => {
     e.preventDefault();
+    const serviceId = e.target['service-id'].value;
     const referral = {
       firstName: e.target.firstName.value,
       lastName: e.target.lastName.value,
@@ -57,7 +59,10 @@ const ResidentDetailsForm = ({
       }
     };
 
-    createReferral(referral);
+    const result = await createReferral(referral);
+    if (result.id) {
+      setReferralCompletion({ success: serviceId });
+    }
   };
   return (
     <div>

--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -2,7 +2,14 @@ import { useState } from 'react';
 import ResourceCard from 'components/Feature/VulnerabilitiesGrid/ResourceCard';
 import { Accordion, AccordionItem } from 'components/Form';
 
-const Services = ({ resources, taxonomies, refererInfo, residentFormCallback }) => {
+const Services = ({
+  resources,
+  taxonomies,
+  refererInfo,
+  residentFormCallback,
+  referralCompletion,
+  setReferralCompletion
+}) => {
   const [expandedGroups, setExpandedGroups] = useState({});
 
   const taxonomiesToRender = taxonomies.filter(taxonomy =>
@@ -43,6 +50,8 @@ const Services = ({ resources, taxonomies, refererInfo, residentFormCallback }) 
                         updateSelectedResources={() => {}}
                         refererInfo={refererInfo}
                         residentFormCallback={residentFormCallback}
+                        referralCompletion={referralCompletion}
+                        setReferralCompletion={setReferralCompletion}
                       />
                     ))}
                   </AccordionItem>

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -153,7 +153,7 @@ const ResourceCard = ({
           }}>
           Refer
         </summary>
-        {!hideForm && referralCompletion.success != id && (
+        {!hideForm && referralCompletion?.success != id && (
           <div hidden={hideForm} id={`referral-${id}-form`}>
             <div
               className={`govuk-form-group govuk-!-padding-bottom-2 ${
@@ -368,7 +368,7 @@ const ResourceCard = ({
             </div>
           </div>
         )}
-        {referralCompletion.success == id && (
+        {referralCompletion?.success == id && (
           <div className={`${css['success-message']}`}>Successfully submitted referral!</div>
         )}
       </details>

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -130,7 +130,11 @@ const ResourceCard = ({
             Distance: distance && distance < 100 ? distance + ' miles' : null,
             Distribution: distributionElement,
             Telephone: telephone,
-            'Service Description': serviceDescription
+            'Service Description': serviceDescription,
+            Address: address,
+            Description: description,
+            Website: websiteElement,
+            'Additional notes': notes
           }}
           customStyle="small"
         />
@@ -365,36 +369,20 @@ const ResourceCard = ({
           </div>
         )}
       </details>
-      <details className="govuk-details" data-module="govuk-details">
-        <summary id={`summary-${id}`} className="">
-          View more information
-        </summary>
-        <SummaryList
-          key={`moreResourceInfo-${id}-${categoryId}`}
-          name={'moreResourceInfo'}
-          entries={{
-            Address: address,
-            Description: description,
-            Website: websiteElement,
-            'Additional notes': notes
-          }}
-          customStyle="small"
-        />
-        {snapshot && (
-          <div className="govuk-checkboxes__item">
-            <input
-              className="govuk-checkboxes__input"
-              id={`input-${id}`}
-              onClick={() => updateResource()}
-              type="checkbox"
-              value={name}
-            />
-            <label className="govuk-label govuk-checkboxes__label" id={`label-${id}`}>
-              Would you like to recommend this resource?
-            </label>
-          </div>
-        )}
-      </details>
+      {snapshot && (
+        <div className="govuk-checkboxes__item">
+          <input
+            className="govuk-checkboxes__input"
+            id={`input-${id}`}
+            onClick={() => updateResource()}
+            type="checkbox"
+            value={name}
+          />
+          <label className="govuk-label govuk-checkboxes__label" id={`label-${id}`}>
+            Would you like to recommend this resource?
+          </label>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -368,6 +368,9 @@ const ResourceCard = ({
             </div>
           </div>
         )}
+        {referralCompletion.success == id && (
+          <div className={`${css['success-message']}`}>Successfully submitted referral!</div>
+        )}
       </details>
       {snapshot && (
         <div className="govuk-checkboxes__item">

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -27,6 +27,8 @@ const ResourceCard = ({
   categoryId,
   refererInfo,
   residentFormCallback,
+  referralCompletion,
+  setReferralCompletion,
   ...others
 }) => {
   const [validationError, setValidationError] = useState({});
@@ -133,7 +135,10 @@ const ResourceCard = ({
           customStyle="small"
         />
       </>
-      <details className="govuk-details" data-module="govuk-details">
+      <details
+        className="govuk-details"
+        data-module="govuk-details"
+        onClick={() => setReferralCompletion({})}>
         <summary
           id={`referral-${id}`}
           type="submit"
@@ -144,7 +149,7 @@ const ResourceCard = ({
           }}>
           Refer
         </summary>
-        {!hideForm && (
+        {!hideForm && referralCompletion.success != id && (
           <div hidden={hideForm} id={`referral-${id}-form`}>
             <div
               className={`govuk-form-group govuk-!-padding-bottom-2 ${
@@ -343,6 +348,7 @@ const ResourceCard = ({
                   onInvalid={e => onInvalidField(e.target.id)}
                   required
                 />
+                <input form="resident-details" value={id} name="service-id" hidden />
               </div>
             </div>
             <div className="govuk-form-group govuk-!-padding-bottom-2">

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.module.scss
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.module.scss
@@ -1,6 +1,5 @@
 @import '../../../../pages/stylesheets/vars.scss';
 
-
 .resource {
   margin-bottom: 0.5em;
   width: 45%;
@@ -19,7 +18,7 @@
   .tags__container {
     margin-bottom: 10px;
   }
-  .label{
+  .label {
     font-weight: bold;
   }
   .tags {
@@ -31,7 +30,7 @@
     font-weight: 600;
     white-space: nowrap;
   }
-  
+
   .Council-tag {
     background-color: #00703c;
   }
@@ -69,4 +68,8 @@
       color: $hackney-green;
     }
   }
+}
+.success-message {
+  background-color: #ddffdd !important;
+  padding: 16px 16px 16px 16px;
 }

--- a/components/Feature/VulnerabilitiesGrid/index.js
+++ b/components/Feature/VulnerabilitiesGrid/index.js
@@ -296,6 +296,8 @@ const VulnerabilitiesGrid = ({
                               {...resource}
                               updateSelectedResources={updateSummaryResource}
                               customerId={customerId}
+                              setReferralCompletion={() => {}}
+                              referralCompletion={null}
                             />
                           );
                         })}

--- a/lib/api/utils/useReferral.js
+++ b/lib/api/utils/useReferral.js
@@ -15,7 +15,7 @@ export default function useReferral(
   function withErrorHandling(fn) {
     return async (...args) => {
       try {
-        await fn(...args);
+        return await fn(...args);
       } catch (err) {
         setError(err);
       }
@@ -31,7 +31,7 @@ export default function useReferral(
       mutate({ ...data, referral });
     }),
     createReferral: withErrorHandling(async referral => {
-      await requestCreateReferral(referral, { token });
+      return await requestCreateReferral(referral, { token });
     })
   };
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,7 +18,7 @@ const Index = ({
   errors,
   refererInfo
 }) => {
-  const { referral, loading, updateReferral } = useReferral(initialReferral.referralId, {
+  const { loading } = useReferral(initialReferral.referralId, {
     initialReferral,
     token
   });
@@ -26,23 +26,19 @@ const Index = ({
   if (loading) {
     return <p>Loading...</p>;
   }
-  const [gernericRefferalFormComplete, setGernericRefferalFormComplete] = useState(false);
-  const [residentInfo, setResidentInfo] = useState(false);
   const [showResidentForm, setShowResidentForm] = useState(false);
+  const [referralCompletion, setReferralCompletion] = useState({ tis: null });
 
   const residentFormCallback = val => {
     setShowResidentForm(val);
   };
-  const residentInfoCallback = value => {
-    setResidentInfo(value);
-  };
   return (
     <>
       <ResidentDetailsForm
-        residentInfoCallback={residentInfoCallback}
         showResidentForm={showResidentForm}
         setShowResidentForm={setShowResidentForm}
         token={token}
+        setReferralCompletion={setReferralCompletion}
       />
       <div>
         {errors.map(err => (
@@ -59,10 +55,10 @@ const Index = ({
       <Services
         taxonomies={fssTaxonomies}
         resources={resources}
-        gernericRefferalFormComplete={gernericRefferalFormComplete}
-        residentInfo={residentInfo}
         refererInfo={refererInfo}
         residentFormCallback={residentFormCallback}
+        referralCompletion={referralCompletion}
+        setReferralCompletion={setReferralCompletion}
       />
       <a
         href="https://forms.gle/B6vEMgp7sCsjJqNdA"


### PR DESCRIPTION
**What**  
Return result from createReferral (currently returns an object with id if record in the database was created)
If ID exists set success message for the referal

<img width="353" alt="image" src="https://user-images.githubusercontent.com/54268893/111606680-69ec3580-87cf-11eb-9703-feccb126ebd1.png">

The "refer" details element doesn't collapse. The success message is displayed instead of the form. 
The idea for the future is to collapse the "refer" element whenever a different "refer" is clicked and expanded