### PR TITLE
Make a referral

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -55,8 +55,6 @@ const fssResourcesGateway = new FssResourcesGateway({
   baseUrl: process.env.FSS_PUBLIC_API_URL
 });
 
-const createReferral = withLogging(new CreateReferral({ referralGateway, logger }), logger);
-
 const notifyGateway = new NotifyGateway({
   apiKey: process.env.GOV_NOTIFY_API_KEY
 });
@@ -79,10 +77,15 @@ const getPrompts = withLogging(
 
 const findFssResources = new FindFssResources({ fssResourcesGateway });
 
-const sendReferralEmail = withLogging(new SendReferralEmail({ notifyGateway, logger }), logger);
+const sendReferralEmail = new SendReferralEmail({ notifyGateway });
 
 const sendReferralReceiptEmail = withLogging(
   new SendReferralReceiptEmail({ notifyGateway, logger }),
+  logger
+);
+
+const createReferral = withLogging(
+  new CreateReferral({ referralGateway, sendReferralEmail, logger }),
   logger
 );
 

--- a/lib/domain/referral.js
+++ b/lib/domain/referral.js
@@ -1,38 +1,29 @@
 import { IsoDateTime } from './isodate';
 
 export default class Referral {
-  constructor({
-    id,
-    created,
-    createdBy,
-    firstName,
-    lastName,
-    phone,
-    email,
-    address,
-    postcode,
-    referralReason,
-    conversationNotes,
-    referrerOrganisation,
-    referrerEmail,
-    dateOfBirth
-  }) {
+  constructor({ id, created, resident, referrer, referralReason, conversationNotes, service, systemIds }) {
     this.id = id;
     this.created = created ? created : IsoDateTime.now();
-    this.createdBy = createdBy;
-    this.firstName = firstName;
-    this.postcode = postcode;
-    this.lastName = lastName;
-    this.phone = phone;
-    this.email = email;
-    this.address = address;
+    this.resident = resident;
+    this.referrer = referrer;
     this.referralReason = referralReason;
     this.conversationNotes = conversationNotes;
-    this.referrerOrganisation = referrerOrganisation;
-    this.referrerEmail = referrerEmail;
-    this.dateOfBirth = dateOfBirth;
+    this.service = service;
+    this.systemIds = systemIds;
+    // this.created = created ? created : IsoDateTime.now();
+    // this.createdBy = createdBy;
+    // this.firstName = firstName;
+    // this.postcode = postcode;
+    // this.lastName = lastName;
+    // this.phone = phone;
+    // this.email = email;
+    // this.address = address;
+    // this.referralReason = referralReason;
+    // this.conversationNotes = conversationNotes;
+    // this.referrerOrganisation = referrerOrganisation;
+    // this.referrerEmail = referrerEmail;
+    // this.dateOfBirth = dateOfBirth;
   }
 
   // dynamodb ttl
-  expires;
 }

--- a/lib/domain/referral.js
+++ b/lib/domain/referral.js
@@ -1,14 +1,54 @@
 import { IsoDateTime } from './isodate';
 
 export default class Referral {
-  constructor({ id, created, resident, referrer, referralReason, conversationNotes, service, systemIds }) {
+  constructor({
+    firstName,
+    lastName,
+    phone,
+    email,
+    address,
+    postcode,
+    referralReason,
+    conversationNotes,
+    referrerOrganisation,
+    referrerName,
+    referrerEmail,
+    dateOfBirth,
+    serviceId,
+    serviceName,
+    serviceContactEmail,
+    serviceReferralEmail,
+    systemIds,
+    created,
+                resident,
+                referrer,
+                service,
+    id
+  }) {
     this.id = id;
     this.created = created ? created : IsoDateTime.now();
-    this.resident = resident;
-    this.referrer = referrer;
+    this.resident = resident ? resident : {
+      firstName,
+      lastName,
+      phone,
+      email,
+      address,
+      postcode,
+      dateOfBirth
+    };
+    this.referrer = referrer ? referrer : {
+      name: referrerName,
+      organisation: referrerOrganisation,
+      email: referrerEmail
+    };
     this.referralReason = referralReason;
     this.conversationNotes = conversationNotes;
-    this.service = service;
+    this.service = service ? service : {
+      id: serviceId,
+      name: serviceName,
+      contactEmail: serviceContactEmail,
+      referralEmail: serviceReferralEmail
+    };
     this.systemIds = systemIds;
   }
 }

--- a/lib/domain/referral.js
+++ b/lib/domain/referral.js
@@ -10,20 +10,5 @@ export default class Referral {
     this.conversationNotes = conversationNotes;
     this.service = service;
     this.systemIds = systemIds;
-    // this.created = created ? created : IsoDateTime.now();
-    // this.createdBy = createdBy;
-    // this.firstName = firstName;
-    // this.postcode = postcode;
-    // this.lastName = lastName;
-    // this.phone = phone;
-    // this.email = email;
-    // this.address = address;
-    // this.referralReason = referralReason;
-    // this.conversationNotes = conversationNotes;
-    // this.referrerOrganisation = referrerOrganisation;
-    // this.referrerEmail = referrerEmail;
-    // this.dateOfBirth = dateOfBirth;
   }
-
-  // dynamodb ttl
 }

--- a/lib/gateways/models/createModelFromReferral.js
+++ b/lib/gateways/models/createModelFromReferral.js
@@ -24,7 +24,7 @@ export function createReferralModel(referral) {
 
   return nullifyEmptyStrings({
     ...referral,
-    queryFirstName: normalise(referral.firstName),
-    queryLastName: normalise(referral.lastName)
+    queryFirstName: normalise(referral.resident.firstName),
+    queryLastName: normalise(referral.resident.lastName)
   });
 }

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -10,36 +10,24 @@ class ReferralGateway {
   }
 
   async create({
-    createdBy,
-    firstName,
-    lastName,
-    phone,
-    email,
-    address,
-    postcode,
+    resident,
+    referrer,
     referralReason,
     conversationNotes,
-    referrerOrganisation,
-    referrerEmail,
-    dateOfBirth
+    service,
+    systemIds
   }) {
-    if (!firstName) throw new ArgumentError('first name cannot be null.');
-    if (!lastName) throw new ArgumentError('last name cannot be null.');
+    // if (!firstName) throw new ArgumentError('first name cannot be null.');
+    // if (!lastName) throw new ArgumentError('last name cannot be null.');
 
     const referral = new Referral({
       id: nanoid(8),
-      createdBy,
-      firstName,
-      lastName,
-      phone,
-      email,
-      address,
-      postcode,
+      resident,
+      referrer,
       referralReason,
       conversationNotes,
-      referrerOrganisation,
-      referrerEmail,
-      dateOfBirth
+      service,
+      systemIds
     });
 
     const request = {

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -17,8 +17,8 @@ class ReferralGateway {
     service,
     systemIds
   }) {
-    // if (!firstName) throw new ArgumentError('first name cannot be null.');
-    // if (!lastName) throw new ArgumentError('last name cannot be null.');
+    if (!resident?.firstName) throw new ArgumentError('first name cannot be null.');
+    if (!resident?.lastName) throw new ArgumentError('last name cannot be null.');
 
     const referral = new Referral({
       id: nanoid(8),

--- a/lib/gateways/referral-gateway.test.js
+++ b/lib/gateways/referral-gateway.test.js
@@ -90,23 +90,6 @@ describe('ReferralGateway', () => {
       expect(result.resident.firstName).toEqual(firstName);
       expect(result.resident.lastName).toEqual(lastName);
     });
-
-    xit('adds a ttl', async () => {
-      //we don't want to remove referrals this needs to be deleted
-      const now = '2020-01-01T04:05:00.000Z';
-      MockDate.set(now);
-      const then = moment(now)
-        .add(12, 'hours')
-        .unix();
-      const referralGateway = new ReferralGateway({ client, tableName });
-
-      const result = await referralGateway.create({
-        firstName: 'Hello',
-        lastName: 'Nasty'
-      });
-
-      expect(result.expires).toEqual(then);
-    });
   });
 
   describe('get', () => {

--- a/lib/gateways/referral-gateway.test.js
+++ b/lib/gateways/referral-gateway.test.js
@@ -41,27 +41,54 @@ describe('ReferralGateway', () => {
     it('can create a referral', async () => {
       const firstName = 'Trevor';
       const lastName = 'McLevor';
+      const conversationNotes = 'Good talk';
+      const referralReason = 'Needs help';
+      const referrerName = 'El';
+      const serviceName = 'Here to help';
 
       const expectedRequest = {
         TableName: tableName,
         Item: expect.objectContaining({
           id: expect.any(String),
-          firstName,
-          lastName,
+          resident: {
+            firstName,
+            lastName
+          },
+          referrer: {
+            name: referrerName
+          },
+          referralReason,
+          conversationNotes,
+          service: {
+            name: serviceName
+          },
           queryFirstName: firstName.toLowerCase(),
           queryLastName: lastName.toLowerCase()
         })
       };
       const referralGateway = new ReferralGateway({ client, tableName });
 
-      const result = await referralGateway.create({ firstName, lastName });
+      const result = await referralGateway.create({
+        resident: {
+          firstName,
+          lastName
+        },
+        referrer: {
+          name: referrerName
+        },
+        referralReason,
+        conversationNotes,
+        service: {
+          name: serviceName
+        }
+      });
 
       expect(client.put).toHaveBeenCalledWith(expectedRequest);
       expect(result).toBeInstanceOf(Referral);
       expect(result.id).toStrictEqual(expect.any(String));
       expect(result.id.length).toBe(8);
-      expect(result.firstName).toEqual(firstName);
-      expect(result.lastName).toEqual(lastName);
+      expect(result.resident.firstName).toEqual(firstName);
+      expect(result.resident.lastName).toEqual(lastName);
     });
 
     xit('adds a ttl', async () => {
@@ -98,7 +125,7 @@ describe('ReferralGateway', () => {
       const lastName = 'McLevor';
 
       client.query = jest.fn(() => ({
-        promise: jest.fn(() => ({ Items: [{ id, firstName, lastName }] }))
+        promise: jest.fn(() => ({ Items: [{ id, resident: { firstName, lastName } }] }))
       }));
       const expectedRequest = {
         TableName: tableName,
@@ -114,8 +141,8 @@ describe('ReferralGateway', () => {
       expect(client.query).toHaveBeenCalledWith(expectedRequest);
       expect(result).toBeInstanceOf(Referral);
       expect(result.id).toEqual(id);
-      expect(result.firstName).toEqual(firstName);
-      expect(result.lastName).toEqual(lastName);
+      expect(result.resident.firstName).toEqual(firstName);
+      expect(result.resident.lastName).toEqual(lastName);
     });
 
     it('can return null if referral does not exist', async () => {

--- a/lib/infrastructure/logging/with-logging.js
+++ b/lib/infrastructure/logging/with-logging.js
@@ -1,6 +1,6 @@
 /**
  * Wraps a use-case with request/response logging.
- * @param {IUseCase} usecase the use case to execute
+ * @param {CreateReferral} usecase the use case to execute
  * @param {ILogger} logger the logger to use
  */
 export function withLogging(usecase, logger) {

--- a/lib/infrastructure/logging/with-logging.js
+++ b/lib/infrastructure/logging/with-logging.js
@@ -1,6 +1,6 @@
 /**
  * Wraps a use-case with request/response logging.
- * @param {CreateReferral} usecase the use case to execute
+ * @param {IUseCase} usecase the use case to execute
  * @param {ILogger} logger the logger to use
  */
 export function withLogging(usecase, logger) {

--- a/lib/use-cases/create-referral.js
+++ b/lib/use-cases/create-referral.js
@@ -1,8 +1,9 @@
 import { convertObjectToIsoDate } from 'lib/utils/date';
 
 export default class CreateReferral {
-  constructor({ referralGateway }) {
+  constructor({ referralGateway, sendReferralEmail }) {
     this.referralGateway = referralGateway;
+    this.sendReferralEmail = sendReferralEmail;
   }
 
   async execute({
@@ -38,10 +39,32 @@ export default class CreateReferral {
       systemIds
     });
 
+    const referral_email = await this.sendReferralEmail.execute({
+      email: referral.email,
+      referral: {
+        name: referral.firstName,
+        phone: referral.phone,
+        email: referral.email,
+        referralReason: referral.referralReason,
+        conversationNotes: referral.conversationNotes,
+        referrerName: referral.createdBy,
+        referrerOrganisation: referral.referrerOrganisation,
+        referrerEmail: referral.referrerEmail
+      }
+    });
+
+    const errors = [];
+
+    if (referral_email.response.status > 201) {
+      errors.push('Failed to send referral email to service');
+    }
+
+    console.log(referral_email.response.status);
     return {
       id: referral.id,
       firstName: referral.firstName,
-      lastName: referral.lastName
+      lastName: referral.lastName,
+      errors: errors
     };
   }
 }

--- a/lib/use-cases/create-referral.js
+++ b/lib/use-cases/create-referral.js
@@ -7,49 +7,35 @@ export default class CreateReferral {
   }
 
   async execute({
-    createdBy,
-    firstName,
-    lastName,
-    phone,
-    email,
-    address,
-    postcode,
+    resident,
+    referrer,
     referralReason,
     conversationNotes,
-    referrerOrganisation,
-    referrerEmail,
-    dateOfBirth,
+    service,
     systemIds = []
   }) {
-    const isoDob = convertObjectToIsoDate(dateOfBirth);
+    resident.dateOfBirth = convertObjectToIsoDate(resident.dateOfBirth);
 
     const referral = await this.referralGateway.create({
-      createdBy,
-      firstName,
-      lastName,
-      phone,
-      email,
-      address,
-      postcode,
+      resident,
+      referrer,
       referralReason,
       conversationNotes,
-      referrerOrganisation,
-      referrerEmail,
-      dateOfBirth: isoDob,
+      service,
       systemIds
     });
 
     const referral_email = await this.sendReferralEmail.execute({
-      email: referral.email,
+      email: service.referralEmail,
       referral: {
-        name: referral.firstName,
-        phone: referral.phone,
-        email: referral.email,
+        name: resident.firstName,
+        phone: resident.phone,
+        email: resident.email,
         referralReason: referral.referralReason,
         conversationNotes: referral.conversationNotes,
-        referrerName: referral.createdBy,
-        referrerOrganisation: referral.referrerOrganisation,
-        referrerEmail: referral.referrerEmail
+        referrerName: referrer.name,
+        referrerOrganisation: referrer.organisation,
+        referrerEmail: referrer.email
       }
     });
 

--- a/lib/use-cases/create-referral.test.js
+++ b/lib/use-cases/create-referral.test.js
@@ -73,7 +73,7 @@ describe('Create Referral use case', () => {
         email,
         address,
         postcode,
-        dateOfBirth: '1980-02-23T00:00:00.000Z',
+        dateOfBirth: `${dateOfBirth.year}-${dateOfBirth.month}-${dateOfBirth.day}T00:00:00.000Z`,
       },
       referrer: {
         name: referrerName,

--- a/lib/use-cases/create-referral.test.js
+++ b/lib/use-cases/create-referral.test.js
@@ -3,7 +3,7 @@ import CreateReferral from 'lib/use-cases/create-referral';
 describe('Create Referral use case', () => {
   it('creates a new referral', async () => {
     const id = 1;
-    const createdBy = 'Tina Turner';
+    const referrerName = 'Tina Turner';
     const dateOfBirth = { day: '23', month: '02', year: '1980' };
     const firstName = 'Bart';
     const lastName = 'Simpson';
@@ -16,6 +16,11 @@ describe('Create Referral use case', () => {
     const referralReason = 'Marge was concerned';
     const referrerEmail = 'email@email.com';
     const referrerOrganisation = 'Hackney';
+    const serviceId = 2;
+    const serviceName = 'ABC service';
+    const serviceContactEmail = 'abc@email.com';
+    const serviceReferralEmail = 'referralservice@email.com'
+
     const referralGateway = {
       create: jest.fn(() => ({
         id,
@@ -25,7 +30,7 @@ describe('Create Referral use case', () => {
         phone,
         referralReason,
         conversationNotes,
-        createdBy,
+        referrerName,
         referrerOrganisation,
         referrerEmail
       }))
@@ -36,39 +41,58 @@ describe('Create Referral use case', () => {
     const createReferral = new CreateReferral({ referralGateway, sendReferralEmail });
 
     const result = await createReferral.execute({
-      createdBy,
-      dateOfBirth,
-      firstName,
-      lastName,
-      phone,
-      email,
-      address,
-      postcode,
+      resident: {
+        firstName,
+        lastName,
+        phone,
+        email,
+        address,
+        postcode,
+        dateOfBirth,
+      },
+      referrer: {
+        name: referrerName,
+        organisation: referrerOrganisation,
+        email: referrerEmail
+      },
       referralReason,
       conversationNotes,
-      systemIds,
-      referrerEmail,
-      referrerOrganisation
+      service: {
+        id: serviceId,
+        name: serviceName,
+        contactEmail: serviceContactEmail,
+        referralEmail: serviceReferralEmail
+      },
     });
 
     expect(referralGateway.create).toHaveBeenCalledWith({
-      createdBy,
-      dateOfBirth: `${dateOfBirth.year}-${dateOfBirth.month}-${dateOfBirth.day}T00:00:00.000Z`,
-      firstName,
-      lastName,
-      phone,
-      email,
-      address,
-      postcode,
+      resident: {
+        firstName,
+        lastName,
+        phone,
+        email,
+        address,
+        postcode,
+        dateOfBirth: '1980-02-23T00:00:00.000Z',
+      },
+      referrer: {
+        name: referrerName,
+        organisation: referrerOrganisation,
+        email: referrerEmail
+      },
       referralReason,
       conversationNotes,
-      systemIds,
-      referrerEmail,
-      referrerOrganisation
+      service: {
+        id: serviceId,
+        name: serviceName,
+        contactEmail: serviceContactEmail,
+        referralEmail: serviceReferralEmail
+      },
+      systemIds: []
     });
 
     expect(sendReferralEmail.execute).toHaveBeenCalledWith({
-      email,
+      email: serviceReferralEmail,
       referral: {
         conversationNotes,
         email,
@@ -76,7 +100,7 @@ describe('Create Referral use case', () => {
         phone,
         referralReason,
         referrerEmail,
-        referrerName: createdBy,
+        referrerName: referrerName,
         referrerOrganisation
       }
     });

--- a/lib/use-cases/create-referral.test.js
+++ b/lib/use-cases/create-referral.test.js
@@ -17,9 +17,23 @@ describe('Create Referral use case', () => {
     const referrerEmail = 'email@email.com';
     const referrerOrganisation = 'Hackney';
     const referralGateway = {
-      create: jest.fn(() => ({ id, firstName, lastName }))
+      create: jest.fn(() => ({
+        id,
+        firstName,
+        lastName,
+        email,
+        phone,
+        referralReason,
+        conversationNotes,
+        createdBy,
+        referrerOrganisation,
+        referrerEmail
+      }))
     };
-    const createReferral = new CreateReferral({ referralGateway });
+    const sendReferralEmail = {
+      execute: jest.fn(() => ({ response: { status: 300 } }))
+    };
+    const createReferral = new CreateReferral({ referralGateway, sendReferralEmail });
 
     const result = await createReferral.execute({
       createdBy,
@@ -52,6 +66,26 @@ describe('Create Referral use case', () => {
       referrerEmail,
       referrerOrganisation
     });
-    expect(result).toEqual({ id, firstName, lastName });
+
+    expect(sendReferralEmail.execute).toHaveBeenCalledWith({
+      email,
+      referral: {
+        conversationNotes,
+        email,
+        name: firstName,
+        phone,
+        referralReason,
+        referrerEmail,
+        referrerName: createdBy,
+        referrerOrganisation
+      }
+    });
+
+    expect(result).toEqual({
+      id,
+      firstName,
+      lastName,
+      errors: ['Failed to send referral email to service']
+    });
   });
 });

--- a/pages/api/referrals/index.js
+++ b/pages/api/referrals/index.js
@@ -1,7 +1,7 @@
 import createEndpoint from 'lib/api/utils/createEndpoint';
 import Response from 'lib/api/domain/Response';
 import { createReferral } from 'lib/dependencies';
-import { getUsername, getTokenFromAuthHeader } from 'lib/utils/token';
+import { Referral } from '../../../lib/domain';
 
 export const endpoint = ({ createReferral }) =>
   createEndpoint(
@@ -61,30 +61,26 @@ export const endpoint = ({ createReferral }) =>
       },
       headers
     }) => {
-      const referral = await createReferral.execute({
-        resident: {
+      const referral = await createReferral.execute(
+        new Referral({
           firstName,
           lastName,
           phone,
           email,
           address,
           postcode,
+          referralReason,
+          conversationNotes,
+          referrerOrganisation,
+          referrerName,
+          referrerEmail,
           dateOfBirth,
-        },
-        referrer: {
-          name: referrerName,
-          organisation: referrerOrganisation,
-          email: referrerEmail
-        },
-        referralReason,
-        conversationNotes,
-        service: {
-          id: serviceId,
-          name: serviceName,
-          contactEmail: serviceContactEmail,
-          referralEmail: serviceReferralEmail
-        }
-      });
+          serviceId,
+          serviceName,
+          serviceContactEmail,
+          serviceReferralEmail
+        })
+      );
       return Response.created(referral);
     }
   );

--- a/pages/api/referrals/index.js
+++ b/pages/api/referrals/index.js
@@ -8,21 +8,20 @@ export const endpoint = ({ createReferral }) =>
     {
       allowedMethods: ['POST'],
       validators: [
-        {
-          name: 'firstName',
-          failureMessage: 'first name is required',
-          validate: ({ body }) => body.firstName && body.firstName.length > 0
-        },
-        {
-          name: 'lastName',
-          failureMessage: 'last name is required',
-          validate: ({ body }) => body.lastName && body.lastName.length > 0
-        }
+        // {
+        //   name: 'firstName',
+        //   failureMessage: 'first name is required',
+        //   validate: ({ body }) => body.firstName && body.firstName.length > 0
+        // },
+        // {
+        //   name: 'lastName',
+        //   failureMessage: 'last name is required',
+        //   validate: ({ body }) => body.lastName && body.lastName.length > 0
+        // }
       ]
     },
     async ({
       body: {
-        createdBy,
         firstName,
         lastName,
         phone,
@@ -32,24 +31,39 @@ export const endpoint = ({ createReferral }) =>
         referralReason,
         conversationNotes,
         referrerOrganisation,
+        referrerName,
         referrerEmail,
-        dateOfBirth
+        dateOfBirth,
+        serviceId,
+        serviceName,
+        serviceContactEmail,
+        serviceReferralEmail
       },
       headers
     }) => {
       const referral = await createReferral.execute({
-        createdBy,
-        firstName,
-        lastName,
-        phone,
-        email,
-        address,
-        postcode,
+        resident: {
+          firstName,
+          lastName,
+          phone,
+          email,
+          address,
+          postcode,
+          dateOfBirth,
+        },
+        referrer: {
+          name: referrerName,
+          organisation: referrerOrganisation,
+          email: referrerEmail
+        },
         referralReason,
         conversationNotes,
-        referrerOrganisation,
-        referrerEmail,
-        dateOfBirth
+        service: {
+          id: serviceId,
+          name: serviceName,
+          contactEmail: serviceContactEmail,
+          referralEmail: serviceReferralEmail
+        }
       });
       return Response.created(referral);
     }

--- a/pages/api/referrals/index.js
+++ b/pages/api/referrals/index.js
@@ -8,16 +8,36 @@ export const endpoint = ({ createReferral }) =>
     {
       allowedMethods: ['POST'],
       validators: [
-        // {
-        //   name: 'firstName',
-        //   failureMessage: 'first name is required',
-        //   validate: ({ body }) => body.firstName && body.firstName.length > 0
-        // },
-        // {
-        //   name: 'lastName',
-        //   failureMessage: 'last name is required',
-        //   validate: ({ body }) => body.lastName && body.lastName.length > 0
-        // }
+        {
+          name: 'firstName',
+          failureMessage: 'first name is required',
+          validate: ({ body }) => body.firstName && body.firstName.length > 0
+        },
+        {
+          name: 'lastName',
+          failureMessage: 'last name is required',
+          validate: ({ body }) => body.lastName && body.lastName.length > 0
+        },
+        {
+          name: 'serviceReferralEmail',
+          failureMessage: 'service referral email is required',
+          validate: ({ body }) => body.serviceReferralEmail && body.serviceReferralEmail.length > 0
+        },
+        {
+          name: 'email',
+          failureMessage: 'resident email is required',
+          validate: ({ body }) => body.serviceReferralEmail && body.serviceReferralEmail.length > 0
+        },
+        {
+          name: 'serviceId',
+          failureMessage: 'service id is required',
+          validate: ({ body }) => body.serviceReferralEmail && body.serviceReferralEmail.length > 0
+        },
+        {
+          name: 'referrerEmail',
+          failureMessage: 'referrer email is required',
+          validate: ({ body }) => body.serviceReferralEmail && body.serviceReferralEmail.length > 0
+        }
       ]
     },
     async ({

--- a/pages/api/referrals/index.test.js
+++ b/pages/api/referrals/index.test.js
@@ -35,7 +35,7 @@ describe('Create Referral Api', () => {
     const serviceId = 2;
     const serviceName = 'ABC service';
     const serviceContactEmail = 'abc@email.com';
-    const serviceReferralEmail = 'referralservice@email.com'
+    const serviceReferralEmail = 'referralservice@email.com';
 
     const response = await call({
       body: {
@@ -66,7 +66,7 @@ describe('Create Referral Api', () => {
         email,
         address,
         postcode,
-        dateOfBirth,
+        dateOfBirth
       },
       referrer: {
         name: referrerName,
@@ -81,6 +81,9 @@ describe('Create Referral Api', () => {
         contactEmail: serviceContactEmail,
         referralEmail: serviceReferralEmail
       },
+      id: undefined,
+      systemIds: undefined,
+      created: expect.any(String)
     });
     expect(response.statusCode).toBe(201);
   });
@@ -91,23 +94,20 @@ describe('Create Referral Api', () => {
   });
 
   describe('validation', () => {
-    it('returns 400 when no required fields are provided', async () =>{
-      const response = await call({
-        body: {
-
-        }});
+    it('returns 400 when no required fields are provided', async () => {
+      const response = await call({ body: {} });
       expect(response.statusCode).toBe(400);
       const errors = JSON.parse(response.body).errors;
       expect(errors.length).toBe(6);
-      expect(errors[0]).toBe("first name is required");
-      expect(errors[1]).toBe("last name is required");
-      expect(errors[2]).toBe("service referral email is required");
-      expect(errors[3]).toBe("resident email is required");
-      expect(errors[4]).toBe("service id is required");
-      expect(errors[5]).toBe("referrer email is required");
+      expect(errors[0]).toBe('first name is required');
+      expect(errors[1]).toBe('last name is required');
+      expect(errors[2]).toBe('service referral email is required');
+      expect(errors[3]).toBe('resident email is required');
+      expect(errors[4]).toBe('service id is required');
+      expect(errors[5]).toBe('referrer email is required');
     });
   });
-  
+
   it('returns a 500 for other errors', async () => {
     createReferral.execute = jest.fn(() => {
       throw new Error();

--- a/pages/api/referrals/index.test.js
+++ b/pages/api/referrals/index.test.js
@@ -28,43 +28,59 @@ describe('Create Referral Api', () => {
     const conversationNotes = 'nice chat';
     const referrerEmail = 'email@email.com';
     const referrerOrganisation = 'Hackney';
-    const createdBy = 'Me';
+    const referrerName = 'Me';
     const phone = '0712345678';
     const postcode = 'SP1 2RM';
     const referralReason = 'needed tests';
+    const serviceId = 2;
+    const serviceName = 'ABC service';
+    const serviceContactEmail = 'abc@email.com';
+    const serviceReferralEmail = 'referralservice@email.com'
 
     const response = await call({
       body: {
-        createdBy,
-        dateOfBirth,
         firstName,
         lastName,
-        // systemIds,
+        phone,
         email,
         address,
-        conversationNotes,
-        phone,
         postcode,
         referralReason,
+        conversationNotes,
+        referrerOrganisation,
+        referrerName,
         referrerEmail,
-        referrerOrganisation
+        dateOfBirth,
+        serviceId,
+        serviceName,
+        serviceContactEmail,
+        serviceReferralEmail
       },
       headers: {}
     });
     expect(createReferral.execute).toHaveBeenCalledWith({
-      dateOfBirth,
-      createdBy,
-      firstName,
-      lastName,
-      // systemIds,
-      email,
-      address,
-      conversationNotes,
-      phone,
-      postcode,
+      resident: {
+        firstName,
+        lastName,
+        phone,
+        email,
+        address,
+        postcode,
+        dateOfBirth,
+      },
+      referrer: {
+        name: referrerName,
+        organisation: referrerOrganisation,
+        email: referrerEmail
+      },
       referralReason,
-      referrerEmail,
-      referrerOrganisation
+      conversationNotes,
+      service: {
+        id: serviceId,
+        name: serviceName,
+        contactEmail: serviceContactEmail,
+        referralEmail: serviceReferralEmail
+      },
     });
     expect(response.statusCode).toBe(201);
   });
@@ -75,41 +91,23 @@ describe('Create Referral Api', () => {
   });
 
   describe('validation', () => {
-    it('returns 400 when no firstName', async () => {
+    it('returns 400 when no required fields are provided', async () =>{
       const response = await call({
         body: {
-          lastName: 'taylor',
-          systemIds: ['xyz']
-        }
-      });
-      expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.body).errors.length).toBe(1);
-    });
 
-    it('returns 400 when no lastName', async () => {
-      const response = await call({
-        body: {
-          firstName: 'sue',
-          systemIds: ['xyz']
-        }
-      });
+        }});
       expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.body).errors.length).toBe(1);
-    });
-
-    xit('returns 400 when no systemIds', async () => {
-      const response = await call({
-        body: {
-          firstName: 'sue',
-          lastName: 'taylor',
-          systemIds: []
-        }
-      });
-      expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.body).errors.length).toBe(1);
+      const errors = JSON.parse(response.body).errors;
+      expect(errors.length).toBe(6);
+      expect(errors[0]).toBe("first name is required");
+      expect(errors[1]).toBe("last name is required");
+      expect(errors[2]).toBe("service referral email is required");
+      expect(errors[3]).toBe("resident email is required");
+      expect(errors[4]).toBe("service id is required");
+      expect(errors[5]).toBe("referrer email is required");
     });
   });
-
+  
   it('returns a 500 for other errors', async () => {
     createReferral.execute = jest.fn(() => {
       throw new Error();
@@ -118,7 +116,10 @@ describe('Create Referral Api', () => {
       body: {
         firstName: 'sue',
         lastName: 'taylor',
-        systemIds: ['xyz']
+        referrerEmail: 'referrer@email.com',
+        serviceId: 2,
+        serviceReferralEmail: 'service_referrer@email.com',
+        email: 'resident@email.com'
       }
     });
     expect(response.statusCode).toBe(500);


### PR DESCRIPTION
**What**  
Make referral endpoint expect more params and save them and send an email

Now `POST` `http://localdev.hackney.gov.uk:3000/api/referrals` expects the following body

```json
{
    "firstName": "Luna",
    "lastName": "Kitty",
    "phone": "57",
    "email": "kegajaput@mailinator.net",
    "address": "Camilla Wiggins",
    "postcode": "Kato Contreras",
    "referralReason": "Cum fugiat assumend",
    "conversationNotes": "Expedita explicabo ",
    "referrerName": "Solomon Payne",
    "referrerEmail": "sihyvoriwa@mailinator.com",
    "referrerOrganisation": "Bullock Malone Co",
    "dateOfBirth": {
        "year": "2015",
        "month": "4",
        "day": "28"
    },
    "serviceId": 123,
    "serviceName": "Sun in my eyes",
    "serviceContactEmail": "sun@eyes.com",
    "serviceReferralEmail": "getsun@eyes.com"
}
```


**Why**  
so that we know what service residents and that the referrals are sent 

**Anything else?**  
 - Have you added any new third-party libraries?
 - Are any new environment variables or configuration values needed?
 - Anything else in this PR that isn't covered by the what/why?
