### PR TITLE
Removed a second (redundant) feedback button.

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -147,13 +147,6 @@ const Index = ({
           token={token}
         />
       )}
-      <a
-        href="https://forms.gle/B6vEMgp7sCsjJqNdA"
-        target="_blank"
-        className="govuk-button govuk-!-margin-top-5"
-        data-testid="feedback-link-test">
-        Submit feedback
-      </a>
     </>
   );
 };


### PR DESCRIPTION
# What:  
 - Removed the 2nd feedback button (The massive green one at the bottom).
 
  Before             |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/43747286/112614355-14400a80-8e19-11eb-8c80-e5a130007a74.png)  | ![image](https://user-images.githubusercontent.com/43747286/112614443-320d6f80-8e19-11eb-9498-7e665da56147.png)

# Why:
- It was making the user journey more confusing by distracting from the support summary dropdown.

# Ticket:
- Trello ticket number: [174](https://trello.com/c/NeryDgzl/174-remove-submit-feedback-button).

# Notes:
- No tests were associated with that button, hence only 1 file changed.