### PR TITLE
Alpha to beta label and text

### DIFF
--- a/components/Layout/PhaseBanner/index.js
+++ b/components/Layout/PhaseBanner/index.js
@@ -3,7 +3,7 @@ const PhaseBanner = ({ phase, feedbackUrl }) => (
     <p className="govuk-phase-banner__content">
       <strong className="govuk-tag govuk-phase-banner__content__tag">{phase}</strong>
       <span className="govuk-phase-banner__text">
-        Is information about a service missing?{' '}
+        This is our new website design - it's a work in progress. Is information about a service missing?{' '}
         <a className="govuk-link" href={feedbackUrl} target="_blank">
           Please tell us here.
         </a>

--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -12,7 +12,7 @@ const Layout = ({ children }) => (
 
     <div className="govuk-width-container app-width-container">
       <PhaseBanner
-        phase="alpha"
+        phase="beta"
         feedbackUrl="https://docs.google.com/forms/d/1QcYtxO27MEa_0473968JmVHVidG3Nlrl6vaYM0CCWFY"
       />
       <main className="govuk-main-wrapper app-main-class" id="content" role="main">


### PR DESCRIPTION
# What:
- Changed phase banner text from 'Alpha' to 'Beta'.
- Added disclaimer text to the banner saying that tool is a work in progress.

# Why:
- It's been used (and hence tested) by users for some time now.

# Screenshot:

  Before             |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/43747286/116092708-f1b24300-a69d-11eb-9fcb-a2504932dd6e.png) | ![image](https://user-images.githubusercontent.com/43747286/116092512-c4fe2b80-a69d-11eb-87db-19196414e6c5.png)


