### PR TITLE
Summary email

### DIFF
--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -13,7 +13,8 @@ const Services = ({
   setReferralCompletion,
   updateSignpostSummary,
   referrerData,
-  setReferrerData
+  setReferrerData,
+  signpostSummary
 }) => {
   const [openReferralForm, setOpenReferralForm] = useState({});
   const [referralData, setReferralData] = useState({});
@@ -143,6 +144,7 @@ const Services = ({
                 referrerData={referrerData}
                 setReferrerData={setReferrerData}
                 updateSignpostSummary={updateSignpostSummary}
+                signpostSummary={signpostSummary}
               />
             ))}
           </div>

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -7,6 +7,12 @@ import css from '../notification-messages.module.scss';
 import styles from './index.module.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
+import { sendDataToAnalytics, getUserGroup } from 'lib/utils/analytics';
+import {
+  SEND_SUMMARY_SUCCESS,
+  SEND_SUMMARY_INVALID_COUNT,
+  SEND_SUMMARY_SUCCESS_COUNT
+} from 'lib/utils/analyticsConstants';
 
 const SupportSummary = ({
   referralSummary,
@@ -76,8 +82,30 @@ const SupportSummary = ({
     if (result.id) {
       setConversationCompletion(result);
       setHideForm(true);
+      sendDataToAnalytics({
+        action: getUserGroup(referrerData['user-groups']),
+        category: SEND_SUMMARY_SUCCESS_COUNT,
+        label: signpostSummary.length
+      });
+
+      signpostSummary.forEach(signpost => {
+        sendDataToAnalytics({
+          action: getUserGroup(referrerData['user-groups']),
+          category: SEND_SUMMARY_SUCCESS,
+          label: signpost.name
+        });
+      });
     }
   };
+
+  const onInvalidAnalytics = () => {
+    sendDataToAnalytics({
+      action: getUserGroup(referrerData['user-groups']),
+      category: SEND_SUMMARY_INVALID_COUNT,
+      label: signpostSummary.length
+    });
+  };
+
   return (
     <>
       <Heading as="h2" id="summary-header">
@@ -166,7 +194,7 @@ const SupportSummary = ({
                   </div>
                 ))}
             </div>
-            <form id="summary-form" onSubmit={sendSummary}>
+            <form id="summary-form" onInvalid={() => onInvalidAnalytics()} onSubmit={sendSummary}>
               <TextArea
                 value={emailBody}
                 label="Add a note for the resident"

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -4,6 +4,9 @@ import Heading from 'components/Heading';
 import { useState } from 'react';
 import useConversation from 'lib/api/utils/useConversation';
 import css from '../notification-messages.module.scss';
+import styles from './index.module.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 
 const SupportSummary = ({
   referralSummary,
@@ -14,13 +17,15 @@ const SupportSummary = ({
   setEmailBody,
   residentInfo,
   residentFormCallback,
-  token
+  token,
+  updateSignpostSummary
 }) => {
   const { createConversation } = useConversation({ token });
 
   const [hideForm, setHideForm] = useState(true);
   const [formErrorMsg, setFormErrorMsg] = useState(false);
   const [conversationCompletion, setConversationCompletion] = useState(null);
+  const [toBeDeleted, setToBeDeleted] = useState(null);
 
   const toggleDetail = e => {
     if (
@@ -126,7 +131,33 @@ const SupportSummary = ({
             <div className="govuk-!-margin-bottom-5">
               {signpostSummary.length > 0 &&
                 signpostSummary.map(signpost => (
-                  <div className="govuk-!-margin-bottom-1">{signpost.name}</div>
+                  <div className="govuk-!-margin-bottom-1">
+                    {signpost.name}
+                    {toBeDeleted != signpost.name && (
+                      <button
+                        onClick={() => setToBeDeleted(signpost.name)}
+                        className={styles['remove-button']}>
+                        <FontAwesomeIcon icon={faTimesCircle} color="red" />
+                      </button>
+                    )}
+                    {toBeDeleted == signpost.name && (
+                      <>
+                        <strong className={styles['remove-prompt']}>
+                          Are you sure you wish to remove {signpost.name} from the summary?
+                        </strong>
+                        <button
+                          className={`govuk-button govuk-button--secondary ${styles['button']}`}
+                          onClick={() => setToBeDeleted(null)}>
+                          No
+                        </button>
+                        <button
+                          onClick={() => updateSignpostSummary(signpost)}
+                          className={`govuk-button ${styles['button']}`}>
+                          Yes
+                        </button>
+                      </>
+                    )}
+                  </div>
                 ))}
             </div>
             <form id="summary-form" onSubmit={sendSummary}>

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -6,7 +6,7 @@ import useConversation from 'lib/api/utils/useConversation';
 import css from '../notification-messages.module.scss';
 import styles from './index.module.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 
 const SupportSummary = ({
   referralSummary,
@@ -133,14 +133,17 @@ const SupportSummary = ({
                 signpostSummary.map(signpost => (
                   <div className="govuk-!-margin-bottom-1">
                     {toBeDeleted != signpost.name && (
-                      <button
-                        onClick={() => setToBeDeleted(signpost.name)}
-                        className={styles['remove-button']}
-                        data-testid="remove-from-summary">
-                        <FontAwesomeIcon icon={faTimes} color="red" />
-                      </button>
+                      <>
+                        <button
+                          onClick={() => setToBeDeleted(signpost.name)}
+                          className={styles['remove-button']}
+                          disabled={toBeDeleted == signpost.name}
+                          data-testid="remove-from-summary">
+                          <FontAwesomeIcon icon={faTimesCircle} color="red" />
+                        </button>
+                        {signpost.name}
+                      </>
                     )}
-                    {signpost.name}
                     {toBeDeleted == signpost.name && (
                       <div>
                         <strong className={styles['remove-prompt']}>

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -6,7 +6,7 @@ import useConversation from 'lib/api/utils/useConversation';
 import css from '../notification-messages.module.scss';
 import styles from './index.module.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 const SupportSummary = ({
   referralSummary,
@@ -132,16 +132,16 @@ const SupportSummary = ({
               {signpostSummary.length > 0 &&
                 signpostSummary.map(signpost => (
                   <div className="govuk-!-margin-bottom-1">
-                    {signpost.name}
                     {toBeDeleted != signpost.name && (
                       <button
                         onClick={() => setToBeDeleted(signpost.name)}
                         className={styles['remove-button']}>
-                        <FontAwesomeIcon icon={faTimesCircle} color="red" />
+                        <FontAwesomeIcon icon={faTimes} color="red" />
                       </button>
                     )}
+                    {signpost.name}
                     {toBeDeleted == signpost.name && (
-                      <>
+                      <div>
                         <strong className={styles['remove-prompt']}>
                           Are you sure you wish to remove {signpost.name} from the summary?
                         </strong>
@@ -155,7 +155,7 @@ const SupportSummary = ({
                           className={`govuk-button ${styles['button']}`}>
                           Yes
                         </button>
-                      </>
+                      </div>
                     )}
                   </div>
                 ))}

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -135,7 +135,8 @@ const SupportSummary = ({
                     {toBeDeleted != signpost.name && (
                       <button
                         onClick={() => setToBeDeleted(signpost.name)}
-                        className={styles['remove-button']}>
+                        className={styles['remove-button']}
+                        data-testid="remove-from-summary">
                         <FontAwesomeIcon icon={faTimes} color="red" />
                       </button>
                     )}
@@ -147,12 +148,14 @@ const SupportSummary = ({
                         </strong>
                         <button
                           className={`govuk-button govuk-button--secondary ${styles['button']}`}
-                          onClick={() => setToBeDeleted(null)}>
+                          onClick={() => setToBeDeleted(null)}
+                          data-testid="remove-from-summary-no">
                           No
                         </button>
                         <button
                           onClick={() => updateSignpostSummary(signpost)}
-                          className={`govuk-button ${styles['button']}`}>
+                          className={`govuk-button ${styles['button']}`}
+                          data-testid="remove-from-summary-yes">
                           Yes
                         </button>
                       </div>

--- a/components/Feature/SupportSummary/index.module.scss
+++ b/components/Feature/SupportSummary/index.module.scss
@@ -5,7 +5,7 @@
   color: red;
   text-decoration: underline;
   cursor: pointer;
-  padding-left: 10px;
+  padding-right: 10px;
 }
 .button {
   margin: 0 0 0 10px;
@@ -14,6 +14,5 @@
 }
 
 .remove-prompt {
-  margin-left: 10px;
   font-size: small;
 }

--- a/components/Feature/SupportSummary/index.module.scss
+++ b/components/Feature/SupportSummary/index.module.scss
@@ -2,17 +2,20 @@
   background: none;
   border: none;
   padding: 0;
-  color: red;
-  text-decoration: underline;
   cursor: pointer;
-  padding-right: 10px;
+  margin-right: 10px;
+  width: 35px;
+  height: 35px;
+  font-size: medium;
 }
+
 .button {
   margin: 0 0 0 10px;
-  padding: 2px;
-  font-size: small;
+  padding: 4px;
+  font-size: medium;
 }
 
 .remove-prompt {
-  font-size: small;
+  font-size: medium;
+  margin-left: 45px;
 }

--- a/components/Feature/SupportSummary/index.module.scss
+++ b/components/Feature/SupportSummary/index.module.scss
@@ -1,0 +1,19 @@
+.remove-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: red;
+  text-decoration: underline;
+  cursor: pointer;
+  padding-left: 10px;
+}
+.button {
+  margin: 0 0 0 10px;
+  padding: 2px;
+  font-size: small;
+}
+
+.remove-prompt {
+  margin-left: 10px;
+  font-size: small;
+}

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -5,7 +5,8 @@ import { sendDataToAnalytics, getUserGroup } from 'lib/utils/analytics';
 import {
   REFERRAL_OPEN,
   REFERRAL_CLICK_WEBSITE,
-  SERVICE_CLICK_WEBSITE
+  SERVICE_CLICK_WEBSITE,
+  VIEW_SUMMARY_EMAIL_CLICKED
 } from 'lib/utils/analyticsConstants';
 
 const ResourceCard = ({
@@ -603,7 +604,16 @@ const ResourceCard = ({
           className={`${css['success-message']}`}
           data-testid={`added-to-summary-banner-${id}-${categoryId}`}>
           You have added a service to your sumary email
-          <a className={`${css['summary-link']}`} href="#summary-header">
+          <a
+            className={`${css['summary-link']}`}
+            href="#summary-header"
+            onClick={() =>
+              sendDataToAnalytics({
+                action: getUserGroup(referrerData['user-groups']),
+                category: VIEW_SUMMARY_EMAIL_CLICKED,
+                label: name
+              })
+            }>
             View summary email
           </a>
         </div>

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -36,6 +36,7 @@ const ResourceCard = ({
   setReferrerData,
   demographic,
   updateSignpostSummary,
+  signpostSummary,
   councilTags,
   ...others
 }) => {
@@ -126,6 +127,7 @@ const ResourceCard = ({
               });
             }}
             value={true}
+            checked={signpostSummary?.some(x => x.name == name)}
           />
           <label
             className="govuk-label govuk-checkboxes__label"

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -172,6 +172,7 @@ const ResourceCard = ({
                   });
                 }}
                 value={true}
+                checked={signpostSummary?.some(x => x.name == name)}
               />
               <label
                 className={`govuk-label govuk-checkboxes__label ${css['checkbox-label']}`}
@@ -588,6 +589,14 @@ const ResourceCard = ({
               Successfully submitted referral
             </div>
           )}
+        </div>
+      )}
+      {signpostSummary?.some(x => x.name == name) && (
+        <div className={`${css['success-message']}`}>
+          You have added a service to your sumary email{' '}
+          <a className={`${css['summary-link']}`} href="#summary-header">
+            view summary email
+          </a>
         </div>
       )}
       {snapshot && (

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -592,7 +592,9 @@ const ResourceCard = ({
         </div>
       )}
       {signpostSummary?.some(x => x.name == name) && (
-        <div className={`${css['success-message']}`}>
+        <div
+          className={`${css['success-message']}`}
+          data-testid={`added-to-summary-banner-${id}-${categoryId}`}>
           You have added a service to your sumary email{' '}
           <a className={`${css['summary-link']}`} href="#summary-header">
             view summary email

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -186,7 +186,12 @@ const ResourceCard = ({
               <span id={`referral-${id}-${categoryId}-details`} name="refer-details">
                 <button
                   id={`referral-${id}-${categoryId}`}
-                  className={`govuk-button ${css['refer-button']}`}
+                  className={`govuk-button ${css['refer-button']} 
+                  ${
+                    openReferralForm.id == id && openReferralForm.categoryName == categoryName
+                      ? 'govuk-button--secondary'
+                      : ''
+                  } `}
                   type="button"
                   data-testid="refer-button"
                   onClick={e => {
@@ -197,7 +202,9 @@ const ResourceCard = ({
                       label: name
                     });
                   }}>
-                  Create Referral
+                  {openReferralForm.id == id && openReferralForm.categoryName == categoryName
+                    ? 'Cancel'
+                    : 'Create Referral'}
                 </button>
                 {openReferralForm.id == id &&
                   openReferralForm.categoryName == categoryName &&
@@ -595,9 +602,9 @@ const ResourceCard = ({
         <div
           className={`${css['success-message']}`}
           data-testid={`added-to-summary-banner-${id}-${categoryId}`}>
-          You have added a service to your sumary email{' '}
+          You have added a service to your sumary email
           <a className={`${css['summary-link']}`} href="#summary-header">
-            view summary email
+            View summary email
           </a>
         </div>
       )}

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.module.scss
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.module.scss
@@ -15,15 +15,15 @@
   }
 
   .header-container {
-      h3 {
-        margin: 0;
-        width: 100%;
-      }
+    h3 {
+      margin: 0;
+      width: 100%;
+    }
 
-      span {
-        color: #525a5b;
-        font-size: 13px;
-      }
+    span {
+      color: #525a5b;
+      font-size: 13px;
+    }
   }
 
   .contact-container {
@@ -130,8 +130,19 @@
   padding: 16px 16px 16px 16px;
 }
 .success-message {
-  background-color: #ddffdd !important;
+  background-color: #dbedc2 !important;
 }
 .error-message {
   background-color: #f4ccccff !important;
+}
+
+.success-message {
+  background-color: #dbedc2 !important;
+  border-left: 2px solid;
+  border-color: #8aa367;
+  margin-top: 16px;
+}
+
+.summary-link {
+  float: right;
 }

--- a/components/Feature/notification-messages.module.scss
+++ b/components/Feature/notification-messages.module.scss
@@ -3,7 +3,7 @@
   padding: 16px 16px 16px 16px;
 }
 .success-message {
-  background-color: #ddffdd !important;
+  background-color: #dbedc2 !important;
 }
 .error-message {
   background-color: #f4ccccff !important;

--- a/components/Feature/notification-messages.module.scss
+++ b/components/Feature/notification-messages.module.scss
@@ -4,6 +4,9 @@
 }
 .success-message {
   background-color: #dbedc2 !important;
+  border-left: 2px solid;
+  border-color: #8aa367;
+  margin-top: 16px;
 }
 .error-message {
   background-color: #f4ccccff !important;

--- a/cypress/integration/features/createSumarry.spec.js
+++ b/cypress/integration/features/createSumarry.spec.js
@@ -57,14 +57,15 @@ context('Create summary', () => {
         '\n' +
         'We discussed the following services in our conversation today:\n' +
         '    1. First service\n' +
-        '    07000 0000000 \n' +
+        '    07000 0000000 ' +
         '\n' +
-        '    help@gmail.com \n' +
+        '    help@gmail.com ' +
         '\n' +
-        '    404 error, not, found \n' +
+        '    404 error, not, found ' +
         '\n' +
-        '    https://www.sample.org.uk \n' +
+        '    https://www.sample.org.uk ' +
         ' \n' +
+        '\n' +
         '\n' +
         '\n' +
         'Thanks, \n' +
@@ -102,25 +103,27 @@ context('Create summary', () => {
         '\n' +
         'We discussed the following services in our conversation today:\n' +
         '    1. First service\n' +
-        '    07000 0000000 \n' +
+        '    07000 0000000 ' +
         '\n' +
-        '    help@gmail.com \n' +
+        '    help@gmail.com ' +
         '\n' +
-        '    404 error, not, found \n' +
+        '    404 error, not, found ' +
         '\n' +
-        '    https://www.sample.org.uk \n' +
+        '    https://www.sample.org.uk ' +
         ' \n' +
+        '\n' +
         '\n' +
         'I referred you to the following services:\n' +
         '    1. Kingsman\n' +
-        '    123456789 \n' +
+        '    123456789 ' +
         '\n' +
-        '    service@test.testy.com \n' +
+        '    service@test.testy.com ' +
         '\n' +
-        '    1 test Rd, London \n' +
+        '    1 test Rd, London ' +
         '\n' +
-        '    https://sample.com/test_kingsman \n' +
+        '    https://sample.com/test_kingsman ' +
         ' \n' +
+        '\n' +
         '\n' +
         'Thanks, \n' +
         `${referrerName}\n` +

--- a/cypress/integration/features/createSumarry.spec.js
+++ b/cypress/integration/features/createSumarry.spec.js
@@ -138,6 +138,22 @@ context('Create summary', () => {
     cy.get('#summary-organisation').should('have.value', refererOrganisation);
   });
 
+  it('can cancel removal of services from summary', () => {
+    cy.get('[data-testid=remove-from-summary]')
+      .first()
+      .click();
+    cy.get('[data-testid=remove-from-summary-no]').click();
+    cy.get('#support-summary-note').should('contain', 'First service');
+  });
+
+  it('can remove services from summary', () => {
+    cy.get('[data-testid=remove-from-summary]')
+      .first()
+      .click();
+    cy.get('[data-testid=remove-from-summary-yes]').click();
+    cy.get('#support-summary-note').should('not.contain', 'First service');
+  });
+
   it('should display success message', () => {
     cy.intercept('/api/conversations', {
       status: 201,

--- a/cypress/integration/features/createSummary.spec.js
+++ b/cypress/integration/features/createSummary.spec.js
@@ -45,7 +45,11 @@ context('Create summary', () => {
       .eq(1)
       .click();
 
+    cy.get('[data-testid=added-to-summary-banner-1-2]').should('not.exist');
+
     cy.get('#add-to-summary-checkbox-1-2').click();
+
+    cy.get('[data-testid=added-to-summary-banner-1-2]').should('exist');
 
     cy.get('#summary-summary-form').click();
 

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -203,4 +203,26 @@ context('Index page', () => {
         .should('contain', 'Second service');
     });
   });
+
+  describe('Add to summary', () => {
+    it('persists checked summaries across different service views', () => {
+      cy.get('[data-testid=category-card]')
+        .eq(1)
+        .click();
+      cy.get('#add-to-summary-checkbox-1-2').should('not.be.checked');
+
+      cy.get('#add-to-summary-checkbox-1-2').click();
+
+      cy.get('#add-to-summary-checkbox-1-2').should('be.checked');
+
+      cy.get('[data-testid=category-card]')
+        .eq(2)
+        .click();
+
+      cy.get('[data-testid=category-card]')
+        .eq(1)
+        .click();
+      cy.get('#add-to-summary-checkbox-1-2').should('be.checked');
+    });
+  });
 });

--- a/lib/utils/analyticsConstants.js
+++ b/lib/utils/analyticsConstants.js
@@ -5,6 +5,10 @@ export const REFERRAL_CLICK_WEBSITE = 'Click Referral Website';
 export const SERVICE_CLICK_WEBSITE = 'Click Service Website';
 export const REFERRAL_SUBMIT_SUCCESS = 'Submit Referral (Success)';
 export const REFERRAL_SUBMIT_INVALID = 'Submit Referral (Invalid)';
+export const VIEW_SUMMARY_EMAIL_CLICKED = 'Click View Summary Email';
+export const SEND_SUMMARY_SUCCESS = 'Send Summary (Success)';
+export const SEND_SUMMARY_INVALID_COUNT = 'Summary Services Count (Invalid)';
+export const SEND_SUMMARY_SUCCESS_COUNT = 'Summary Services Count';
 
 export const ANALYTICS_GROUPS = {
   'Better Conversations User Group 1': 'C19 Helpline',

--- a/lib/utils/analyticsConstants.js
+++ b/lib/utils/analyticsConstants.js
@@ -8,7 +8,7 @@ export const REFERRAL_SUBMIT_INVALID = 'Submit Referral (Invalid)';
 export const VIEW_SUMMARY_EMAIL_CLICKED = 'Click View Summary Email';
 export const SEND_SUMMARY_SUCCESS = 'Send Summary (Success)';
 export const SEND_SUMMARY_INVALID_COUNT = 'Summary Services Count (Invalid)';
-export const SEND_SUMMARY_SUCCESS_COUNT = 'Summary Services Count';
+export const SEND_SUMMARY_SUCCESS_COUNT = 'Summary Services Count (Success)';
 
 export const ANALYTICS_GROUPS = {
   'Better Conversations User Group 1': 'C19 Helpline',

--- a/lib/utils/getEmailBody.js
+++ b/lib/utils/getEmailBody.js
@@ -27,10 +27,10 @@ ${referrerData['referer-organisation'] || ''}
 
 const getServiceSummaryText = (index, service) => {
   return `${index + 1}. ${service.name || ''}
-    ${service.telephone || ''} \n
-    ${service.contactEmail || ''} \n
-    ${service.address || ''} \n
-    ${service.websites || ''} \n \n`;
+    ${service.telephone || ''} 
+    ${service.contactEmail || ''} 
+    ${service.address || ''} 
+    ${service.websites || ''}  \n\n`;
 };
 
 export { getEmailBody };

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react-test-renderer": "16.13.1",
     "sass": "^1.26.5",
     "serverless": "^1.70.1",
+    "serverless-plugin-metric": "^1.2.2",
     "start-server-and-test": "^1.11.0"
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -93,6 +93,7 @@ const Index = ({ categorisedResources, initialReferral, token, errors, refererIn
         referralCompletion={referralCompletion}
         setReferralCompletion={setReferralCompletion}
         updateSignpostSummary={updateSignpostSummary}
+        signpostSummary={signpostSummary}
         referrerData={referrerData}
         setReferrerData={setReferrerData}
       />

--- a/pages/index.js
+++ b/pages/index.js
@@ -97,6 +97,7 @@ const Index = ({ categorisedResources, initialReferral, token, errors, refererIn
         signpostSummary={signpostSummary}
         referrerData={referrerData}
         setReferrerData={setReferrerData}
+        signpostSummary={signpostSummary}
       />
       <SupportSummary
         referralSummary={referralSummary}

--- a/pages/index.js
+++ b/pages/index.js
@@ -97,7 +97,6 @@ const Index = ({ categorisedResources, initialReferral, token, errors, refererIn
         signpostSummary={signpostSummary}
         referrerData={referrerData}
         setReferrerData={setReferrerData}
-        signpostSummary={signpostSummary}
       />
       <SupportSummary
         referralSummary={referralSummary}

--- a/pages/index.js
+++ b/pages/index.js
@@ -100,6 +100,7 @@ const Index = ({ categorisedResources, initialReferral, token, errors, refererIn
         referralSummary={referralSummary}
         residentFormCallback={residentFormCallback}
         signpostSummary={signpostSummary}
+        updateSignpostSummary={updateSignpostSummary}
         referrerData={referrerData}
         setReferrerData={setReferrerData}
         residentInfo={residentInfo}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10380,6 +10380,11 @@ serverless-http@^2.4.1:
   optionalDependencies:
     "@types/aws-lambda" "^8.10.19"
 
+serverless-plugin-metric@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/serverless-plugin-metric/-/serverless-plugin-metric-1.2.2.tgz#c546bea629061a5cd73f7c81d6c4e1aea6c8d1b6"
+  integrity sha512-Wd19bclaFMaEtOtKv37+6XFVVNC9GkjXOWSYM5nebZRqSfK9Iyr4qOfatJmeyUvH4YVT4ZH3n53GzZwRtkfwPQ==
+
 serverless@^1.70.1:
   version "1.79.0"
   resolved "https://registry.yarnpkg.com/serverless/-/serverless-1.79.0.tgz#5bbe9bb3651c6b673b5b688f7bb09e9c9c9b31be"


### PR DESCRIPTION
**What**  
Enable the removal of services added to the summary email:
Before:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/54268893/121366459-6a5d1e00-c931-11eb-92ad-283a7d27fb19.png">

After:
<img width="859" alt="image" src="https://user-images.githubusercontent.com/54268893/121656612-91356480-ca97-11eb-9d14-acb2594d792d.png">

Add banner for when the service is checked:
<img width="949" alt="image" src="https://user-images.githubusercontent.com/54268893/121656913-de193b00-ca97-11eb-8356-8eeede99c564.png">

Format the email:
Before:
<img width="872" alt="image" src="https://user-images.githubusercontent.com/54268893/121366418-6204e300-c931-11eb-9023-ce1923d612ec.png">
After:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/54268893/121366263-3f72ca00-c931-11eb-8a5f-c62ec2c758c0.png">

**Why**  
To make the summary emailing process easier and the page content more informative.

