### PR TITLE
Make resident email non mandatory 

### DIFF
--- a/components/Feature/ReferralForm/index.js
+++ b/components/Feature/ReferralForm/index.js
@@ -38,6 +38,9 @@ const ReferralForm = ({
 
   const handleOnChange = (id, value) => {
     delete validationError[id];
+    if (id == 'email' && value == '') {
+      document.getElementById('resident-referral-email').checked = false;
+    }
     let newResidentInfo = { ...residentInfo, [id]: value };
     setResidentInfo(newResidentInfo);
   };
@@ -137,6 +140,7 @@ const ReferralForm = ({
                 handleOnChange={handleOnChange}
                 preserveFormData={preserveFormData}
                 residentInfo={residentInfo}
+                formType="referral"
               />
             </div>
             <div className={`govuk-grid-column-one-half`}>
@@ -319,6 +323,7 @@ const ReferralForm = ({
                         name="resident-referral-email"
                         type="checkbox"
                         value={true}
+                        disabled={residentInfo.email == null || residentInfo.email == ''}
                       />
                       <label
                         className="govuk-label govuk-checkboxes__label"

--- a/components/Feature/ResidentDetails/index.js
+++ b/components/Feature/ResidentDetails/index.js
@@ -5,7 +5,8 @@ const ResidentDetails = ({
   onInvalidField,
   handleOnChange,
   preserveFormData,
-  residentInfo
+  residentInfo,
+  formType
 }) => {
   return (
     <div>
@@ -103,7 +104,7 @@ const ResidentDetails = ({
             spellCheck="false"
             defaultValue={preserveFormData ? residentInfo?.email : ''}
             onChange={e => handleOnChange(e.target.id, e.target.value)}
-            required
+            required={formType == 'summary'}
             onInvalid={e => onInvalidField(e.target.id)}
           />
         </div>

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -209,6 +209,7 @@ const SupportSummary = ({
                 handleOnChange={handleOnChange}
                 preserveFormData={preserveFormData}
                 residentInfo={residentInfo}
+                formType="summary"
               />
               <TextArea
                 value={emailBody}

--- a/cypress/integration/features/createReferral.spec.js
+++ b/cypress/integration/features/createReferral.spec.js
@@ -122,7 +122,6 @@ describe('Referral form', () => {
         cy.get('#firstName').should('have.class', 'govuk-input--error');
         cy.get('#lastName').should('have.class', 'govuk-input--error');
         cy.get('#phone').should('have.class', 'govuk-input--error');
-        cy.get('#email').should('have.class', 'govuk-input--error');
         cy.get('#address').should('have.class', 'govuk-input--error');
         cy.get('#postcode').should('have.class', 'govuk-input--error');
       });


### PR DESCRIPTION
Make resident email non mandatory for referral forms and disable/uncheck sharing referral receipt with the resident when no email is entered

<img width="420" alt="image" src="https://user-images.githubusercontent.com/54268893/122074677-5150e300-cdf1-11eb-882e-6a57f268c326.png">
<img width="446" alt="image" src="https://user-images.githubusercontent.com/54268893/122074696-56159700-cdf1-11eb-8826-eb69da83bff2.png">
