### PR TITLE
move onbeforeunload script 

### DIFF
--- a/lib/utils/analyticsConstants.js
+++ b/lib/utils/analyticsConstants.js
@@ -15,5 +15,6 @@ export const ANALYTICS_GROUPS = {
   'Better Conversations User Group 2': 'ASC Front Door',
   'Better Conversations User Group 3': 'ASC Information & Assessment',
   'Better Conversations User Group 4': 'External',
+  'Better Conversations User Group 5': 'Early Help',
   Other: 'Other'
 };

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,7 +15,6 @@ export default class MyApp extends App {
           <Component {...pageProps} />
         </Layout>
         <script src="/js/govuk.js"></script>
-        {process.env.NEXT_PUBLIC_ENV != 'test' && <script src="/js/beforeUnload.js"></script>}
       </>
     );
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -60,6 +60,7 @@ const Index = ({ categorisedResources, initialReferral, token, errors, refererIn
     <>
       <Head>
         <title>Better Conversations</title>
+        {process.env.NEXT_PUBLIC_ENV != 'test' && <script src="/js/beforeUnload.js"></script>}
       </Head>
       <div className="govuk-!-margin-top-9">
         {errors.map((err, index) => (


### PR DESCRIPTION
**What**  
move onbeforeunload script  to the individual page instead of all of them

**Why**  
To avoid alert showing on privacy and logged out pages ([ticket](https://hackney.atlassian.net/jira/software/projects/HTHA/boards/57?selectedIssue=HTHA-119))