### PR TITLE
Prevent duplicate analytics events when an invalid form is attempted …

### DIFF
--- a/components/Feature/ReferralForm/index.js
+++ b/components/Feature/ReferralForm/index.js
@@ -35,6 +35,7 @@ const ReferralForm = ({
   const { createReferral } = useReferral({ token });
 
   const [validationError, setValidationError] = useState({});
+  const [analyticsSubmitted, setAnalyticsSubmitted] = useState(false);
 
   const handleOnChange = (id, value) => {
     delete validationError[id];
@@ -126,10 +127,14 @@ const ReferralForm = ({
           <form
             id={`referral-form-${id}`}
             onInvalid={() => {
-              sendDataToAnalytics({
-                action: getUserGroup(referrerData['user-groups']),
-                category: REFERRAL_SUBMIT_INVALID
-              });
+              if (!analyticsSubmitted) {
+                sendDataToAnalytics({
+                  action: getUserGroup(referrerData['user-groups']),
+                  category: REFERRAL_SUBMIT_INVALID,
+                  label: name
+                });
+                setAnalyticsSubmitted(true);
+              }
             }}
             onSubmit={onSubmitForm}>
             <div

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -31,6 +31,7 @@ const SupportSummary = ({
   setPreserveFormData
 }) => {
   const [validationError, setValidationError] = useState({});
+  const [analyticsSubmitted, setAnalyticsSubmitted] = useState(false);
 
   const { createConversation } = useConversation({ token });
 
@@ -204,7 +205,15 @@ const SupportSummary = ({
                   </div>
                 ))}
             </div>
-            <form id="summary-form" onInvalid={() => onInvalidAnalytics()} onSubmit={sendSummary}>
+            <form
+              id="summary-form"
+              onInvalid={() => {
+                if (!analyticsSubmitted) {
+                  onInvalidAnalytics();
+                  setAnalyticsSubmitted(true);
+                }
+              }}
+              onSubmit={sendSummary}>
               <ResidentDetails
                 onInvalidField={onInvalidField}
                 validationError={validationError}


### PR DESCRIPTION
**What**  
Prevented Google Analytics events firing more than once for an invalid form.

**Why**  
The onInvalid method is called for each invalid field, not each attempt to submit an invalid form. This leads to a larger than expected number of analytics events if an invalid form is submitted.

