### PR TITLE
Accessibility

### DIFF
--- a/components/Feature/ReferralForm/index.js
+++ b/components/Feature/ReferralForm/index.js
@@ -225,7 +225,7 @@ const ReferralForm = ({
                 </label>
                 {validationError[`referral-reason-${id}`] && (
                   <span
-                    id="more-detail-error"
+                    id="referral-reason-error"
                     className={` ${
                       validationError[`referral-reason-${id}`] ? 'govuk-error-message' : ''
                     }`}>
@@ -239,7 +239,7 @@ const ReferralForm = ({
                   id={`referral-reason-${id}`}
                   name="referral-reason"
                   rows="5"
-                  aria-describedby="more-detail-hint more-detail-error"
+                  aria-describedby="referral-reason-error"
                   defaultValue={preserveFormData ? referralData['referral-reason'] : ''}
                   onChange={e => {
                     setReferralData({ ...referralData, 'referral-reason': e.target.value });
@@ -258,7 +258,7 @@ const ReferralForm = ({
                 </label>
                 {validationError[`conversation-notes-${id}`] && (
                   <span
-                    id="more-detail-error"
+                    id="conversation-notes-error"
                     className={` ${
                       validationError[`conversation-notes-${id}`] ? 'govuk-error-message' : ''
                     }`}>
@@ -272,7 +272,7 @@ const ReferralForm = ({
                   id={`conversation-notes-${id}`}
                   name="conversation-notes"
                   rows="5"
-                  aria-describedby="more-detail-hint more-detail-error"
+                  aria-describedby="conversation-notes-error"
                   defaultValue={preserveFormData ? referralData['conversation-notes'] : ''}
                   onChange={e => {
                     setReferralData({
@@ -370,7 +370,7 @@ const ReferralForm = ({
                     </legend>
                   </label>
                   <span
-                    id="name-error"
+                    id="referrer-name-error"
                     className="govuk-error-message"
                     aria-describedby="input-name-error">
                     <span hidden={!validationError[`referer-name-${id}`]} data-testid="name-error">
@@ -404,7 +404,7 @@ const ReferralForm = ({
                     </legend>
                   </label>
                   <span
-                    id="name-error"
+                    id="referrer-organisation-error"
                     className="govuk-error-message"
                     aria-describedby="input-name-error">
                     <span
@@ -443,7 +443,7 @@ const ReferralForm = ({
                     </legend>
                   </label>
                   <span
-                    id="name-error"
+                    id="referrer-email-error"
                     className="govuk-error-message"
                     aria-describedby="input-name-error">
                     <span hidden={!validationError[`referer-email-${id}`]} data-testid="name-error">

--- a/components/Feature/ReferralForm/index.js
+++ b/components/Feature/ReferralForm/index.js
@@ -218,7 +218,10 @@ const ReferralForm = ({
                 className={`govuk-form-group govuk-!-padding-bottom-2 govuk-!-padding-top-4 ${
                   validationError[`referral-reason-${id}`] ? 'govuk-form-group--error' : ''
                 }`}>
-                <label className="govuk-label inline" htmlFor={`referral-reason-${id}`}>
+                <label
+                  id="referral-reason-label"
+                  className="govuk-label inline"
+                  htmlFor={`referral-reason-${id}`}>
                   <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
                     Reason for referral, please give as much detail as possible
                   </legend>
@@ -239,7 +242,7 @@ const ReferralForm = ({
                   id={`referral-reason-${id}`}
                   name="referral-reason"
                   rows="5"
-                  aria-describedby="referral-reason-error"
+                  aria-describedby="referral-reason-label"
                   defaultValue={preserveFormData ? referralData['referral-reason'] : ''}
                   onChange={e => {
                     setReferralData({ ...referralData, 'referral-reason': e.target.value });
@@ -251,7 +254,10 @@ const ReferralForm = ({
                 className={`govuk-form-group govuk-!-padding-bottom-2 ${
                   validationError[`conversation-notes-${id}`] ? 'govuk-form-group--error' : ''
                 }`}>
-                <label className="govuk-label inline" htmlFor={`conversation-notes-${id}`}>
+                <label
+                  id="conversation-notes-label"
+                  className="govuk-label inline"
+                  htmlFor={`conversation-notes-${id}`}>
                   <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
                     Notes on wider conversation(other needs, living situation, key information
                   </legend>
@@ -272,7 +278,7 @@ const ReferralForm = ({
                   id={`conversation-notes-${id}`}
                   name="conversation-notes"
                   rows="5"
-                  aria-describedby="conversation-notes-error"
+                  aria-describedby="conversation-notes-label"
                   defaultValue={preserveFormData ? referralData['conversation-notes'] : ''}
                   onChange={e => {
                     setReferralData({
@@ -287,8 +293,11 @@ const ReferralForm = ({
                 className={`govuk-form-group govuk-!-padding-bottom-2 ${
                   validationError[`consent-${id}`] ? 'govuk-form-group--error' : ''
                 }`}>
-                <fieldset className="govuk-fieldset" aria-describedby="consent-hint">
-                  <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
+                <fieldset className="govuk-fieldset">
+                  <legend
+                    id="consent-label"
+                    className="govuk-fieldset__legend govuk-fieldset__legend--s"
+                    htmlFor={`consent-${id}`}>
                     The resident is happy for their information to be shared with third parties
                   </legend>
                   <div className="govuk-checkboxes govuk-checkboxes--inline">
@@ -307,6 +316,7 @@ const ReferralForm = ({
                         value="true"
                         onInvalid={e => onInvalidField(e.target.id)}
                         required
+                        aria-describedby="consent-label"
                       />
                       <label
                         className="govuk-label govuk-checkboxes__label"
@@ -364,15 +374,15 @@ const ReferralForm = ({
                   className={`govuk-form-group govuk-!-padding-bottom-2 ${
                     validationError[`referer-name-${id}`] ? 'govuk-form-group--error' : ''
                   }`}>
-                  <label className="govuk-label inline" htmlFor={`referer-name-${id}`}>
+                  <label
+                    id="referrer-name-label"
+                    className="govuk-label inline"
+                    htmlFor={`referer-name-${id}`}>
                     <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
                       Your name
                     </legend>
                   </label>
-                  <span
-                    id="referrer-name-error"
-                    className="govuk-error-message"
-                    aria-describedby="input-name-error">
+                  <span id="referrer-name-error" className="govuk-error-message">
                     <span hidden={!validationError[`referer-name-${id}`]} data-testid="name-error">
                       Enter your name
                     </span>
@@ -388,8 +398,7 @@ const ReferralForm = ({
                     onChange={e => {
                       setReferrerData({ ...referrerData, 'referer-name': e.target.value });
                     }}
-                    aria-describedby="refererName-hint"
-                    aria-describedby="refererName"
+                    aria-describedby="referrer-name-label"
                     onInvalid={e => onInvalidField(e.target.id)}
                     required
                   />
@@ -398,15 +407,15 @@ const ReferralForm = ({
                   className={`govuk-form-group govuk-!-padding-bottom-2 ${
                     validationError[`referer-organisation-${id}`] ? 'govuk-form-group--error' : ''
                   }`}>
-                  <label className="govuk-label inline" htmlFor={`referer-organisation-${id}`}>
+                  <label
+                    id="referrer-organisation-label"
+                    className="govuk-label inline"
+                    htmlFor={`referer-organisation-${id}`}>
                     <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
                       Your organisation
                     </legend>
                   </label>
-                  <span
-                    id="referrer-organisation-error"
-                    className="govuk-error-message"
-                    aria-describedby="input-name-error">
+                  <span id="referrer-organisation-error" className="govuk-error-message">
                     <span
                       hidden={!validationError[`referer-organisation-${id}`]}
                       data-testid="name-error">
@@ -427,8 +436,7 @@ const ReferralForm = ({
                         'referer-organisation': e.target.value
                       });
                     }}
-                    aria-describedby="refererorganisation-hint"
-                    aria-describedby="refererorganisation"
+                    aria-describedby="referrer-organisation-label"
                     onInvalid={e => onInvalidField(e.target.id)}
                     required
                   />
@@ -437,15 +445,15 @@ const ReferralForm = ({
                   className={`govuk-form-group govuk-!-padding-bottom-2 ${
                     validationError[`referer-email-${id}`] ? 'govuk-form-group--error' : ''
                   }`}>
-                  <label className="govuk-label inline" htmlFor={`referer-email-${id}`}>
+                  <label
+                    id="referrer-email-label"
+                    className="govuk-label inline"
+                    htmlFor={`referer-email-${id}`}>
                     <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
                       Your email
                     </legend>
                   </label>
-                  <span
-                    id="referrer-email-error"
-                    className="govuk-error-message"
-                    aria-describedby="input-name-error">
+                  <span id="referrer-email-error" className="govuk-error-message">
                     <span hidden={!validationError[`referer-email-${id}`]} data-testid="name-error">
                       Enter your email
                     </span>
@@ -461,12 +469,14 @@ const ReferralForm = ({
                     onChange={e => {
                       setReferrerData({ ...referrerData, 'referer-email': e.target.value });
                     }}
-                    aria-describedby="refererorganisation-hint"
-                    aria-describedby="refererorganisation"
+                    aria-describedby="referrer-email-label"
                     onInvalid={e => onInvalidField(e.target.id)}
                     required
                   />
-                  <input value={id} name="service-id" hidden />
+                  <label htmlFor={`service-id-${id}`} hidden>
+                    Service name
+                  </label>
+                  <input id={`service-id-${id}`} value={id} name="service-id" hidden />
                 </div>
               </div>
               <div className="govuk-form-group govuk-!-padding-bottom-2">
@@ -480,7 +490,13 @@ const ReferralForm = ({
                     }}>
                     Cancel
                   </button>
-                  <input type="submit" id={`submit-${id}`} className="govuk-button" name="Submit" />
+                  <input
+                    value="Submit"
+                    type="submit"
+                    id={`submit-${id}`}
+                    className="govuk-button"
+                    name="Submit"
+                  />
                 </div>
               </div>
             </div>

--- a/components/Feature/ReferralForm/index.js
+++ b/components/Feature/ReferralForm/index.js
@@ -474,7 +474,7 @@ const ReferralForm = ({
                     required
                   />
                   <label htmlFor={`service-id-${id}`} hidden>
-                    Service name
+                    Service id
                   </label>
                   <input id={`service-id-${id}`} value={id} name="service-id" hidden />
                 </div>

--- a/components/Feature/ResidentDetails/index.js
+++ b/components/Feature/ResidentDetails/index.js
@@ -19,7 +19,10 @@ const ResidentDetails = ({
           validationError.firstName ? 'govuk-form-group--error' : ''
         }`}>
         <div className="govuk-!-padding-bottom-2">
-          <label className="govuk-label inline" htmlFor="firstName">
+          <label
+            id={`first-name-label-${formType}`}
+            className="govuk-label inline"
+            htmlFor="firstName">
             First name
           </label>
           <span id={`first-name-error-${formType}`} className="govuk-error-message">
@@ -34,7 +37,7 @@ const ResidentDetails = ({
             type="text"
             defaultValue={preserveFormData ? residentInfo?.firstName : ''}
             onChange={e => handleOnChange(e.target.id, e.target.value)}
-            aria-describedby="firstName"
+            aria-describedby={`first-name-label-${formType}`}
             onInvalid={e => onInvalidField(e.target.id)}
             required
           />
@@ -43,7 +46,10 @@ const ResidentDetails = ({
       <div
         className={`govuk-form-group ${validationError.lastName ? 'govuk-form-group--error' : ''}`}>
         <div className="govuk-!-padding-bottom-2">
-          <label className="govuk-label inline" htmlFor="lastName">
+          <label
+            id={`last-name-label-${formType}`}
+            className="govuk-label inline"
+            htmlFor="lastName">
             Last name
           </label>
           <span id={`last-name-error-${formType}`} className="govuk-error-message">
@@ -57,7 +63,7 @@ const ResidentDetails = ({
             name="lastName"
             type="text"
             defaultValue={preserveFormData ? residentInfo?.lastName : ''}
-            aria-describedby="lastName"
+            aria-describedby={`last-name-label-${formType}`}
             onChange={e => handleOnChange(e.target.id, e.target.value)}
             onInvalid={e => onInvalidField(e.target.id)}
             required
@@ -66,7 +72,7 @@ const ResidentDetails = ({
       </div>
       <div className={`govuk-form-group ${validationError.phone ? 'govuk-form-group--error' : ''}`}>
         <div className="govuk-!-padding-bottom-2">
-          <label className="govuk-label inline" htmlFor="phone">
+          <label id={`phone-label-${formType}`} className="govuk-label inline" htmlFor="phone">
             Phone
           </label>
           <span id={`phone-error-${formType}`} className="govuk-error-message">
@@ -83,12 +89,13 @@ const ResidentDetails = ({
             defaultValue={preserveFormData ? residentInfo?.phone : ''}
             required
             onInvalid={e => onInvalidField(e.target.id)}
+            aria-describedby={`phone-label-${formType}`}
           />
         </div>
       </div>
       <div className={`govuk-form-group ${validationError.email ? 'govuk-form-group--error' : ''}`}>
         <div className="govuk-!-padding-bottom-2">
-          <label className="govuk-label inline" htmlFor="email">
+          <label id={`email-label-${formType}`} className="govuk-label inline" htmlFor="email">
             Email
           </label>
           <span id={`email-error-${formType}`} className="govuk-error-message">
@@ -106,13 +113,14 @@ const ResidentDetails = ({
             onChange={e => handleOnChange(e.target.id, e.target.value)}
             required={formType == 'summary'}
             onInvalid={e => onInvalidField(e.target.id)}
+            aria-describedby={`email-label-${formType}`}
           />
         </div>
       </div>
       <div
         className={`govuk-form-group ${validationError.address ? 'govuk-form-group--error' : ''}`}>
         <div className="govuk-!-padding-bottom-2">
-          <label className="govuk-label inline" htmlFor="address">
+          <label id={`address-label-${formType}`} className="govuk-label inline" htmlFor="address">
             Address
           </label>
           <span id={`address-error-${formType}`} className="govuk-error-message">
@@ -129,13 +137,17 @@ const ResidentDetails = ({
             onChange={e => handleOnChange(e.target.id, e.target.value)}
             required
             onInvalid={e => onInvalidField(e.target.id)}
+            aria-describedby={`address-label-${formType}`}
           />
         </div>
       </div>
       <div
         className={`govuk-form-group ${validationError.postcode ? 'govuk-form-group--error' : ''}`}>
         <div className="govuk-!-padding-bottom-2">
-          <label className="govuk-label inline" htmlFor="postcode">
+          <label
+            id={`postcode-label-${formType}`}
+            className="govuk-label inline"
+            htmlFor="postcode">
             Postcode
           </label>
           <span id={`postcode-error-${formType}`} className="govuk-error-message">
@@ -152,6 +164,7 @@ const ResidentDetails = ({
             onChange={e => handleOnChange(e.target.id, e.target.value)}
             required
             onInvalid={e => onInvalidField(e.target.id)}
+            aria-describedby={`postcode-label-${formType}`}
           />
         </div>
       </div>
@@ -161,7 +174,10 @@ const ResidentDetails = ({
           <div className="govuk-date-input" id="date-of-birth">
             <div className="govuk-date-input__item">
               <div className="govuk-form-group">
-                <label className="govuk-label govuk-date-input__label" htmlFor="date-of-birth-day">
+                <label
+                  id={`dob-day-label-${formType}`}
+                  className="govuk-label govuk-date-input__label"
+                  htmlFor="date-of-birth-day">
                   Day
                 </label>
                 <input
@@ -175,12 +191,14 @@ const ResidentDetails = ({
                   pattern="[0-9]*"
                   inputMode="numeric"
                   onChange={e => handleOnChange(e.target.id, e.target.value)}
+                  aria-describedby={`dob-day-label-${formType}`}
                 />
               </div>
             </div>
             <div className="govuk-date-input__item">
               <div className="govuk-form-group">
                 <label
+                  id={`dob-month-label-${formType}`}
                   className="govuk-label govuk-date-input__label"
                   htmlFor="date-of-birth-month">
                   Month
@@ -196,12 +214,16 @@ const ResidentDetails = ({
                   pattern="[0-9]*"
                   inputMode="numeric"
                   onChange={e => handleOnChange(e.target.id, e.target.value)}
+                  aria-describedby={`dob-month-label-${formType}`}
                 />
               </div>
             </div>
             <div className="govuk-date-input__item">
               <div className="govuk-form-group">
-                <label className="govuk-label govuk-date-input__label" htmlFor="date-of-birth-year">
+                <label
+                  id={`dob-year-label-${formType}`}
+                  className="govuk-label govuk-date-input__label"
+                  htmlFor="date-of-birth-year">
                   Year
                 </label>
                 <input
@@ -215,6 +237,7 @@ const ResidentDetails = ({
                   pattern="[0-9]*"
                   inputMode="numeric"
                   onChange={e => handleOnChange(e.target.id, e.target.value)}
+                  aria-describedby={`dob-year-label-${formType}`}
                 />
               </div>
             </div>

--- a/components/Feature/ResidentDetails/index.js
+++ b/components/Feature/ResidentDetails/index.js
@@ -10,9 +10,9 @@ const ResidentDetails = ({
 }) => {
   return (
     <div>
-      <h3 className="govuk-heading-m" id="resident-details-header">
+      <h2 className="govuk-heading-m" id="resident-details-header">
         Who are you helping?
-      </h3>
+      </h2>
 
       <div
         className={`govuk-form-group ${
@@ -22,7 +22,7 @@ const ResidentDetails = ({
           <label className="govuk-label inline" htmlFor="firstName">
             First name
           </label>
-          <span id="name-error" className="govuk-error-message">
+          <span id={`first-name-error-${formType}`} className="govuk-error-message">
             <span hidden={!validationError.firstName} data-testid="name-error">
               Enter the first name
             </span>
@@ -46,7 +46,7 @@ const ResidentDetails = ({
           <label className="govuk-label inline" htmlFor="lastName">
             Last name
           </label>
-          <span id="name-error" className="govuk-error-message">
+          <span id={`last-name-error-${formType}`} className="govuk-error-message">
             <span hidden={!validationError.lastName} data-testid="name-error">
               Enter the last name
             </span>
@@ -69,7 +69,7 @@ const ResidentDetails = ({
           <label className="govuk-label inline" htmlFor="phone">
             Phone
           </label>
-          <span id="phone-error" className="govuk-error-message">
+          <span id={`phone-error-${formType}`} className="govuk-error-message">
             <span hidden={!validationError.phone} data-testid="phone-error">
               Enter the phone number
             </span>
@@ -91,7 +91,7 @@ const ResidentDetails = ({
           <label className="govuk-label inline" htmlFor="email">
             Email
           </label>
-          <span id="email-error" className="govuk-error-message">
+          <span id={`email-error-${formType}`} className="govuk-error-message">
             <span hidden={!validationError.email} data-testid="email-error">
               Enter the email address
             </span>
@@ -115,7 +115,7 @@ const ResidentDetails = ({
           <label className="govuk-label inline" htmlFor="address">
             Address
           </label>
-          <span id="address-error" className="govuk-error-message">
+          <span id={`address-error-${formType}`} className="govuk-error-message">
             <span hidden={!validationError.address} data-testid="address-error">
               Enter the address
             </span>
@@ -138,7 +138,7 @@ const ResidentDetails = ({
           <label className="govuk-label inline" htmlFor="postcode">
             Postcode
           </label>
-          <span id="postcode-error" className="govuk-error-message">
+          <span id={`postcode-error-${formType}`} className="govuk-error-message">
             <span hidden={!validationError.postcode} data-testid="postcode-error">
               Enter the postcode
             </span>

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -138,10 +138,10 @@ const SupportSummary = ({
                 Successfully submitted conversation
               </div>
             )}
-            <h4 data-testid="conversation-competition-msg">
+            <h2 data-testid="conversation-competition-msg">
               To help another resident please{' '}
               <a href="javascript:window.location.href=window.location.href">refresh this page</a>
-            </h4>
+            </h2>
           </div>
         )}
         {!hideForm && (

--- a/components/Feature/SupportSummary/index.js
+++ b/components/Feature/SupportSummary/index.js
@@ -138,7 +138,7 @@ const SupportSummary = ({
                 Successfully submitted conversation
               </div>
             )}
-            <h2 data-testid="conversation-competition-msg">
+            <h2 className="govuk-heading-s" data-testid="conversation-competition-msg">
               To help another resident please{' '}
               <a href="javascript:window.location.href=window.location.href">refresh this page</a>
             </h2>

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -64,7 +64,7 @@ const severityIndicators = {
   critical: '🔴'
 };
 const callback = violations => {
-  const threshold = 3;
+  const threshold = 1;
   violations.forEach(violation => {
     const nodes = Cypress.$(violation.nodes.map(node => node.target).join(','));
 


### PR DESCRIPTION
**What**  
Reduce accessibility violation threshold from 3 to 1, so that the automated tests fail if there's more than 1 accessibility violation.

The remaining violation that occurs is documented [here](https://dequeuniversity.com/rules/axe/4.1/region), and it is caused by SkipLink and PhaseBanner being outside of main or header content. It is a known issue with govuk frontend described [here](https://github.com/alphagov/govuk-frontend/issues/1604)


Update form labels.

**Why**  
To increase automated test coverage and confidence in application accessibility standards
