### PR TITLE
Save link ids

### DIFF
--- a/lib/domain/referral.js
+++ b/lib/domain/referral.js
@@ -28,7 +28,10 @@ export default class Referral {
     referrer,
     service,
     emails,
-    id
+    id,
+    linkId,
+    referenceNumber,
+    statusHistory
   }) {
     this.id = id;
     this.emails = emails;
@@ -66,5 +69,8 @@ export default class Referral {
           description: serviceDescription
         };
     this.systemIds = systemIds;
+    this.linkId = linkId;
+    this.referenceNumber = referenceNumber;
+    this.statusHistory = statusHistory;
   }
 }

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -29,7 +29,10 @@ class ReferralGateway {
       conversationNotes,
       service,
       systemIds,
-      emails
+      emails,
+      linkId: nanoid(),
+      referenceNumber: nanoid(5),
+      statusHistory: [{ status: 'SENT', date: new Date.now() }]
     });
 
     const request = {

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -32,7 +32,7 @@ class ReferralGateway {
       systemIds,
       emails,
       linkId: nanoid(),
-      referenceNumber: nanoid(5),
+      referenceNumber: nanoid(5).toUpperCase(),
       statusHistory: [{ status: REFERRAL_STATUSES.Sent, date: IsoDateTime.now() }]
     });
 

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -1,7 +1,8 @@
 import { nanoid } from 'nanoid';
 import { ArgumentError, Referral } from 'lib/domain';
 import { createDomainModel, createReferralFromModel } from './models';
-import moment from 'moment';
+import { IsoDateTime } from '../domain/isodate';
+import { REFERRAL_STATUSES } from 'lib/utils/constants';
 
 class ReferralGateway {
   constructor({ client, tableName }) {
@@ -32,7 +33,7 @@ class ReferralGateway {
       emails,
       linkId: nanoid(),
       referenceNumber: nanoid(5),
-      statusHistory: [{ status: 'SENT', date: new Date.now() }]
+      statusHistory: [{ status: REFERRAL_STATUSES.Sent, date: IsoDateTime.now() }]
     });
 
     const request = {

--- a/lib/gateways/referral-gateway.test.js
+++ b/lib/gateways/referral-gateway.test.js
@@ -50,6 +50,14 @@ describe('ReferralGateway', () => {
         TableName: tableName,
         Item: expect.objectContaining({
           id: expect.any(String),
+          linkId: expect.any(String),
+          referenceNumber: expect.any(String),
+          statusHistory: [
+            {
+              status: 'SENT',
+              date: expect.any(String)
+            }
+          ],
           resident: {
             firstName,
             lastName

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -23,3 +23,7 @@ export const ANALYTICS_GROUPS = {
 export const EMAIL = 'email';
 
 export const LETTER = 'letter';
+
+export const REFERRAL_STATUSES = {
+  Sent: 'SENT'
+};


### PR DESCRIPTION
**What**  
Added LinkId, ReferenceNumber, StatusHistory to referrals and generate initial values on create referral.

**Why**  
To allow us to send referral confirmation links to services so they can provide confirm/deny of a request.
