### PR TITLE
Update status history

### DIFF
--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -100,9 +100,9 @@ class ReferralGateway {
     };
   }
 
-  async save({ referral }) {
+  async update({ referral }) {
     if (!referral) throw new ArgumentError('referral cannot be null.');
-    console.log('Saving referral: ', referral);
+    console.log('Updating referral: ', referral);
     // remove the dynamodb ttl on save
     delete referral.expires;
 

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -103,21 +103,12 @@ class ReferralGateway {
   async update({ referral }) {
     if (!referral) throw new ArgumentError('referral cannot be null.');
     console.log('Updating referral: ', referral);
-    // remove the dynamodb ttl on save
-    delete referral.expires;
 
-    const updateExpression = ['set assets = :a', 'vulnerabilities = :v', 'expires = :e'];
+    const updateExpression = ['set statusHistory = :h'];
 
     const expressionAttributeValues = {
-      ':a': referral.assets,
-      ':v': referral.vulnerabilities,
-      ':e': null
+      ':h': referral.statusHistory
     };
-
-    if (referral.notes) {
-      updateExpression.push('notes = :n');
-      expressionAttributeValues[':n'] = referral.notes;
-    }
 
     const request = {
       TableName: this.tableName,

--- a/lib/gateways/referral-gateway.test.js
+++ b/lib/gateways/referral-gateway.test.js
@@ -349,8 +349,8 @@ describe('ReferralGateway', () => {
     });
   });
 
-  describe('save (actually update)', () => {
-    xit('saves the referral', async () => {
+  describe('update', () => {
+    xit('updates the referral', async () => {
       const referral = new Referral({
         id: 1,
         createdBy: 'Luna',
@@ -381,13 +381,13 @@ describe('ReferralGateway', () => {
       };
       const referralGateway = new ReferralGateway({ client, tableName });
 
-      const result = await referralGateway.save({ referral });
+      const result = await referralGateway.update({ referral });
 
       expect(client.update).toHaveBeenCalledWith(expectedRequest);
       expect(result).toBe(referral);
     });
 
-    it('removes the ttl on save', async () => {
+    it('removes the ttl on update', async () => {
       const referral = new Referral({
         id: 1,
         assets: ['an asset'],
@@ -397,12 +397,12 @@ describe('ReferralGateway', () => {
       referral.expires = 123;
       const referralGateway = new ReferralGateway({ client, tableName });
 
-      const result = await referralGateway.save({ referral });
+      const result = await referralGateway.update({ referral });
 
       expect(result.expires).toBeUndefined();
     });
 
-    it('does not save notes when notes is empty', async () => {
+    it('does not update notes when notes is empty', async () => {
       const referral = new Referral({
         id: 1,
         assets: ['an asset'],
@@ -423,7 +423,7 @@ describe('ReferralGateway', () => {
       };
       const referralGateway = new ReferralGateway({ client, tableName });
 
-      await referralGateway.save({ referral });
+      await referralGateway.update({ referral });
 
       expect(client.update).toHaveBeenCalledWith(expectedRequest);
     });
@@ -434,14 +434,14 @@ describe('ReferralGateway', () => {
       });
       const referralGateway = new ReferralGateway({ client, tableName });
       await expect(async () => {
-        await referralGateway.save({ referral: {} });
+        await referralGateway.update({ referral: {} });
       }).rejects.toThrow();
     });
 
     it('throws an error if referral is null', async () => {
       const referralGateway = new ReferralGateway({ client, tableName });
       await expect(async () => {
-        await referralGateway.save({});
+        await referralGateway.update({});
       }).rejects.toThrow('referral cannot be null.');
       expect(client.update).not.toHaveBeenCalled();
     });

--- a/lib/gateways/referral-gateway.test.js
+++ b/lib/gateways/referral-gateway.test.js
@@ -350,7 +350,11 @@ describe('ReferralGateway', () => {
   });
 
   describe('update', () => {
-    xit('updates the referral', async () => {
+    it('updates the statusHistory for the referral', async () => {
+      const statusHistory = [
+        { status: 'SENT', date: '02/03/2020' },
+        { status: 'ACCEPTED', date: '03/03/2020' }
+      ];
       const referral = new Referral({
         id: 1,
         createdBy: 'Luna',
@@ -362,20 +366,16 @@ describe('ReferralGateway', () => {
         address: '123 Some rd',
         postcode: 'SP2 13N',
         referralReason: 'testing',
-        conversationNotes: 'test dummies can not talk'
+        conversationNotes: 'test dummies can not talk',
+        statusHistory
       });
       const expectedRequest = {
         TableName: tableName,
         Key: { id: referral.id },
         ConditionExpression: 'attribute_exists(id)',
-        UpdateExpression: [
-          'set assets = :a',
-          'vulnerabilities = :v',
-          'expires = :e',
-          'notes = :n'
-        ].join(', '),
+        UpdateExpression: 'set statusHistory = :h',
         ExpressionAttributeValues: {
-          ':e': null
+          ':h': statusHistory
         },
         ReturnValues: 'UPDATED_NEW'
       };
@@ -385,47 +385,6 @@ describe('ReferralGateway', () => {
 
       expect(client.update).toHaveBeenCalledWith(expectedRequest);
       expect(result).toBe(referral);
-    });
-
-    it('removes the ttl on update', async () => {
-      const referral = new Referral({
-        id: 1,
-        assets: ['an asset'],
-        notes: '',
-        vulnerabilities: ['a vulnerability']
-      });
-      referral.expires = 123;
-      const referralGateway = new ReferralGateway({ client, tableName });
-
-      const result = await referralGateway.update({ referral });
-
-      expect(result.expires).toBeUndefined();
-    });
-
-    it('does not update notes when notes is empty', async () => {
-      const referral = new Referral({
-        id: 1,
-        assets: ['an asset'],
-        notes: '',
-        vulnerabilities: ['a vulnerability']
-      });
-      const expectedRequest = {
-        TableName: tableName,
-        Key: { id: referral.id },
-        ConditionExpression: 'attribute_exists(id)',
-        UpdateExpression: ['set assets = :a', 'vulnerabilities = :v', 'expires = :e'].join(', '),
-        ExpressionAttributeValues: {
-          ':a': referral.assets,
-          ':e': null,
-          ':v': referral.vulnerabilities
-        },
-        ReturnValues: 'UPDATED_NEW'
-      };
-      const referralGateway = new ReferralGateway({ client, tableName });
-
-      await referralGateway.update({ referral });
-
-      expect(client.update).toHaveBeenCalledWith(expectedRequest);
     });
 
     it('throws an error if referral does not exist', async () => {

--- a/lib/use-cases/update-referral.js
+++ b/lib/use-cases/update-referral.js
@@ -4,6 +4,6 @@ export default class UpdateReferral {
   }
 
   async execute({ referral }) {
-    await this.referralGateway.save({ referral });
+    await this.referralGateway.update({ referral });
   }
 }

--- a/lib/use-cases/update-referral.test.js
+++ b/lib/use-cases/update-referral.test.js
@@ -2,13 +2,13 @@ import UpdateReferral from './update-referral';
 
 describe('Update Referral use case', () => {
   it('updates a referral', async () => {
-    const referralGateway = { save: jest.fn() };
+    const referralGateway = { update: jest.fn() };
     const referral = { id: 1, assets: [], vulnerabilities: [], notes: '' };
     const updateReferral = new UpdateReferral({ referralGateway });
 
     await updateReferral.execute({ referral });
 
-    expect(referralGateway.save).toHaveBeenCalledWith({
+    expect(referralGateway.update).toHaveBeenCalledWith({
       referral
     });
   });


### PR DESCRIPTION
**What**  
Change the existing update (formerly save) dynamodb gateway method to only update statusHistory.

**Why**  
Because this method is not currently being used and is no longer relevant - we only want to be able to update the statusHistory after the creation of the referral