### PR TITLE
Pass serviceDescription to createReferral

### DIFF
--- a/components/Feature/ReferralForm/index.js
+++ b/components/Feature/ReferralForm/index.js
@@ -208,7 +208,7 @@ const ReferralForm = ({
               <input
                 id={`service-description-${resource.id}`}
                 name="service-description"
-                value={resource.description}
+                value={resource.serviceDescription}
                 type="text"
                 hidden
               />

--- a/pages/api/referrals/index.js
+++ b/pages/api/referrals/index.js
@@ -62,7 +62,8 @@ export const endpoint = ({ createReferral }) =>
         serviceAddress,
         serviceWebsite,
         sendResidentSms,
-        sendResidentEmail
+        sendResidentEmail,
+        serviceDescription
       },
       headers
     }) => {
@@ -86,7 +87,8 @@ export const endpoint = ({ createReferral }) =>
           serviceContactPhone,
           serviceReferralEmail,
           serviceAddress,
-          serviceWebsite
+          serviceWebsite,
+          serviceDescription
         }),
         sendResidentSms,
         sendResidentEmail


### PR DESCRIPTION
**What**  
Pass in the service description when creating a new referral

**Why**  
Resident email contained 'undefined' instead of service description, because of this bug