### PR TITLE
Add ref number to emails and receipts

### DIFF
--- a/config/tables/content/sent.json
+++ b/config/tables/content/sent.json
@@ -1,6 +1,7 @@
 {
   "id": { "S": "11" },
   "linkId": { "S": "1" },
+  "referenceNumber": { "S": "E7UK-8" },
   "created": { "S": "2021-07-21T12:29:17.120Z" },
   "statusHistory": {
     "L": [

--- a/cypress/integration/features/changeStatus.spec.js
+++ b/cypress/integration/features/changeStatus.spec.js
@@ -14,19 +14,23 @@ context('status page', () => {
       cy.get('[data-testid=status-confirmation-panel]').should('contain', 'Thank you');
       cy.get('[data-testid=status-confirmation-panel]').should(
         'contain',
-        'Your decision on this referral has been sent'
+        'Referral reference number: E7UK-8'
       );
-
       cy.runCheckA11y();
+
+      // Test the page after refresh as it's supposed to look different after the referral state is updated.
       cy.visit('/referrals/status/1');
+      cy.injectAxe();
 
       cy.get('[data-testid=status-paragraph]').should('contain', 'This referral was ACCEPTED on');
+      cy.get('[data-testid=reference-number-paragraph]').should('contain', 'Reference number: E7UK-8');
       cy.resetReferralStatus('11', [
         {
           date: '2021-07-20T09:17:23.305Z',
           status: 'SENT'
         }
       ]);
+      cy.runCheckA11y();
     });
   });
 
@@ -45,13 +49,17 @@ context('status page', () => {
       cy.get('[data-testid=status-confirmation-panel]').should('contain', 'Thank you');
       cy.get('[data-testid=status-confirmation-panel]').should(
         'contain',
-        'Your decision on this referral has been sent'
+        'Referral reference number: E7UK-8'
       );
 
       cy.runCheckA11y();
+
+      // Test the page after refresh as it's supposed to look different after the referral state is updated.
       cy.visit('/referrals/status/1');
+      cy.injectAxe();
 
       cy.get('[data-testid=status-paragraph]').should('contain', 'This referral was REJECTED on');
+      cy.get('[data-testid=reference-number-paragraph]').should('contain', 'Reference number: E7UK-8');
       cy.get('[data-testid=status-paragraph]').should('contain', 'with comment: "comment".');
       cy.resetReferralStatus('11', [
         {
@@ -59,6 +67,7 @@ context('status page', () => {
           status: 'SENT'
         }
       ]);
+      cy.runCheckA11y(); //
     });
   });
 });

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -18,7 +18,8 @@ class ReferralGateway {
     service,
     systemIds,
     emails,
-    linkId
+    linkId,
+    referenceNumber
   }) {
     if (!resident?.firstName) throw new ArgumentError('first name cannot be null.');
     if (!resident?.lastName) throw new ArgumentError('last name cannot be null.');
@@ -33,7 +34,7 @@ class ReferralGateway {
       systemIds,
       emails,
       linkId,
-      referenceNumber: nanoid(6).toUpperCase(),
+      referenceNumber,
       statusHistory: [{ status: REFERRAL_STATUSES.Sent, date: IsoDateTime.now() }]
     });
 

--- a/lib/gateways/referral-gateway.test.js
+++ b/lib/gateways/referral-gateway.test.js
@@ -45,13 +45,14 @@ describe('ReferralGateway', () => {
       const referralReason = 'Needs help';
       const referrerName = 'El';
       const serviceName = 'Here to help';
+      const referenceNumber = '8G-E2L';
 
       const expectedRequest = {
         TableName: tableName,
         Item: expect.objectContaining({
           id: expect.any(String),
           linkId: expect.any(String),
-          referenceNumber: expect.any(String),
+          referenceNumber,
           statusHistory: [
             {
               status: 'SENT',
@@ -89,7 +90,8 @@ describe('ReferralGateway', () => {
         service: {
           name: serviceName
         },
-        linkId: '123'
+        linkId: '123',
+        referenceNumber
       });
 
       expect(client.put).toHaveBeenCalledWith(expectedRequest);

--- a/lib/use-cases/create-referral.js
+++ b/lib/use-cases/create-referral.js
@@ -26,6 +26,7 @@ export default class CreateReferral {
 
     const linkId = nanoid();
     const referenceNumber = nanoid(6).toUpperCase();
+
     const referral_email = await this.sendReferralEmail.execute({
       emailAddress: service.referralEmail,
       referral: {
@@ -39,7 +40,8 @@ export default class CreateReferral {
         referrerName: referrer.name,
         referrerOrganisation: referrer.organisation,
         referrerEmail: referrer.email,
-        linkId
+        linkId,
+        referenceNumber
       }
     });
     const errors = [];

--- a/lib/use-cases/create-referral.js
+++ b/lib/use-cases/create-referral.js
@@ -25,6 +25,7 @@ export default class CreateReferral {
     const emailFriendlyDateOfBirth = convertIsoDateToString(resident.dateOfBirth);
 
     const linkId = nanoid();
+    const referenceNumber = nanoid(6).toUpperCase();
     const referral_email = await this.sendReferralEmail.execute({
       emailAddress: service.referralEmail,
       referral: {
@@ -58,7 +59,8 @@ export default class CreateReferral {
         serviceName: `${service.name}`,
         serviceReferralEmail: `${service.referralEmail}`,
         serviceContactPhone: `${service.contactPhone}`,
-        serviceContactEmail: `${service.contactEmail}`
+        serviceContactEmail: `${service.contactEmail}`,
+        referenceCode: referenceNumber
       }
     });
 
@@ -120,7 +122,8 @@ export default class CreateReferral {
         referralResidentEmailId: referral_resident_email?.response.data?.id,
         residentReferralSmsId: residentReferralSms?.response.data?.id
       },
-      linkId
+      linkId,
+      referenceNumber
     });
 
     return {

--- a/lib/use-cases/create-referral.js
+++ b/lib/use-cases/create-referral.js
@@ -62,7 +62,7 @@ export default class CreateReferral {
         serviceReferralEmail: `${service.referralEmail}`,
         serviceContactPhone: `${service.contactPhone}`,
         serviceContactEmail: `${service.contactEmail}`,
-        referenceCode: referenceNumber
+        referenceNumber
       }
     });
 

--- a/lib/use-cases/create-referral.test.js
+++ b/lib/use-cases/create-referral.test.js
@@ -130,7 +130,8 @@ describe('Create Referral use case', () => {
         referralResidentEmailId: undefined,
         residentReferralSmsId: undefined
       },
-      linkId: expect.any(String)
+      linkId: expect.any(String),
+      referenceNumber: expect.any(String)
     });
 
     expect(sendReferralEmail.execute).toHaveBeenCalledWith({
@@ -146,7 +147,8 @@ describe('Create Referral use case', () => {
         referrerEmail,
         referrerName,
         referrerOrganisation,
-        linkId: expect.any(String)
+        linkId: expect.any(String),
+        referenceNumber: expect.any(String)
       }
     });
 
@@ -161,7 +163,8 @@ describe('Create Referral use case', () => {
         serviceContactEmail: serviceContactEmail,
         serviceContactPhone: serviceContactPhone,
         serviceName: serviceName,
-        serviceReferralEmail: serviceReferralEmail
+        serviceReferralEmail: serviceReferralEmail,
+        referenceNumber: expect.any(String)
       }
     });
 

--- a/lib/use-cases/send-referral-email.js
+++ b/lib/use-cases/send-referral-email.js
@@ -15,7 +15,8 @@ export default class SendReferralEmail {
       referrerName: referral.referrerName,
       referrerOrganisation: referral.referrerOrganisation,
       referrerEmail: referral.referrerEmail,
-      statusLink: `${process.env.NEXT_PUBLIC_URL}/referrals/status/${referral.linkId}`
+      statusLink: `${process.env.NEXT_PUBLIC_URL}/referrals/status/${referral.linkId}`,
+      referenceNumber: referral.referenceNumber
     };
     return await this.notifyGateway.sendEmail(
       process.env.REFERRAL_EMAIL_TEMPLATE_ID,

--- a/lib/use-cases/send-referral-receipt-email.js
+++ b/lib/use-cases/send-referral-receipt-email.js
@@ -14,7 +14,7 @@ export default class SendReferralReceiptEmail {
       serviceReferralEmail: referral.serviceReferralEmail,
       serviceContactPhone: referral.serviceContactPhone,
       serviceContactEmail: referral.serviceContactEmail,
-      referenceCode: referral.referenceCode
+      referenceNumber: referral.referenceNumber
     };
     return await this.notifyGateway.sendEmail(
       process.env.REFERRAL_RECEIPT_EMAIL_TEMPLATE_ID,

--- a/lib/use-cases/send-referral-receipt-email.js
+++ b/lib/use-cases/send-referral-receipt-email.js
@@ -13,7 +13,8 @@ export default class SendReferralReceiptEmail {
       serviceName: referral.serviceName,
       serviceReferralEmail: referral.serviceReferralEmail,
       serviceContactPhone: referral.serviceContactPhone,
-      serviceContactEmail: referral.serviceContactEmail
+      serviceContactEmail: referral.serviceContactEmail,
+      referenceCode: referral.referenceCode
     };
     return await this.notifyGateway.sendEmail(
       process.env.REFERRAL_RECEIPT_EMAIL_TEMPLATE_ID,

--- a/lib/use-cases/send-referral-response-email.js
+++ b/lib/use-cases/send-referral-response-email.js
@@ -15,7 +15,7 @@ export default class SendReferralResponseEmail {
       name: referral.name,
       referrerName: referral.referrerName,
       serviceName: referral.serviceName,
-      referenceCode: referral.referenceNumber || '',
+      referenceNumber: referral.referenceNumber || '',
       comments: recentStatus.comment
     };
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "unit-test": "jest --runInBand",
     "dynamo-admin": "DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin",
     "lint": "eslint --fix --ext js lib/ pages/ && echo 'Lint complete.'",
-    "pretty": "prettier --write \"./**/*.{js,jsx,json}\""
+    "pretty": "prettier --write \"./**/*.{js,jsx,json}\"",
+    "dynamo": "docker-compose up dynamodb"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.35",

--- a/pages/referrals/status/[id].js
+++ b/pages/referrals/status/[id].js
@@ -57,19 +57,26 @@ const StatusHistory = ({ referral }) => {
               className="govuk-panel govuk-panel--confirmation"
               data-testid="status-confirmation-panel">
               <h1 className="govuk-panel__title">Thank you</h1>
-              <div className="govuk-panel__body">Your decision on this referral has been sent</div>
+              <div className="govuk-panel__body">
+                Referral reference number:
+                <br /> {referral.referenceNumber}
+              </div>
             </div>
-            <h2 className="govuk-heading-m">What happens next</h2>
+            <p>Your decision on this referral has been sent.</p>
+            <h2 className="govuk-heading-m">What happens next?</h2>
             <p>We’ve let the referrer know your response.</p>
           </div>
         </div>
       ) : recentStatus.status == REFERRAL_STATUSES.Accepted ||
         recentStatus.status == REFERRAL_STATUSES.Rejected ? (
-        <h1 className="govuk-heading-m" data-testid="status-paragraph">
-          This referral was {recentStatus.status} on{' '}
-          {convertIsoDateToDateTimeString(new Date(recentStatus.date))}
-          {recentStatus.comment && ` with comment: "${recentStatus.comment}".`}
-        </h1>
+        <>
+          <h1 className="govuk-heading-m" data-testid="status-paragraph">
+            This referral was {recentStatus.status} on{' '}
+            {convertIsoDateToDateTimeString(new Date(recentStatus.date))}
+            {recentStatus.comment && ` with comment: "${recentStatus.comment}".`}
+          </h1>
+          <p className="govuk-hint">Reference number: {referral.referenceNumber}</p>
+        </>
       ) : (
         <StatusForm
           onSubmitForm={onSubmitForm}

--- a/pages/referrals/status/[id].js
+++ b/pages/referrals/status/[id].js
@@ -75,7 +75,7 @@ const StatusHistory = ({ referral }) => {
             {convertIsoDateToDateTimeString(new Date(recentStatus.date))}
             {recentStatus.comment && ` with comment: "${recentStatus.comment}".`}
           </h1>
-          <p className="govuk-hint">Reference number: {referral.referenceNumber}</p>
+          <p className="govuk-hint" data-testid="reference-number-paragraph">Reference number: {referral.referenceNumber}</p>
         </>
       ) : (
         <StatusForm


### PR DESCRIPTION
# What:
- Added Reference Number to Success confirmation message and Accepted/Rejected referral messages on Status Page.
- Added Reference Number parameter to "Referral" & "Referral Receipt" email templates.

# Why:  
- To share the common id between referrer & service.
- To have an identifier with which to chase up on at every stage of referral process.

# Notes:
- Moved out the generation of Reference Number from the 'referral-gateway' to the 'create-referral' use-case.
- Added a shorter command to start up the local "dynamodb" instance into node scripts.
- Added a <br/> newline because the automatic word wrapping was wrapping on the hyphens "-" within reference number.
- Added additional accessibility cypress checks within accept/reject referral tests for the way page is displayed after refresh. 
- Co-authored with @kosiakkatrina.