### PR TITLE
html encode the comment using 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cookie": "^0.4.1",
     "cookie-parser": "^1.4.5",
     "govuk-frontend": "^3.6.0",
+    "html-entities": "^2.3.2",
     "jsonwebtoken": "^8.5.1",
     "markdown-to-jsx": "^6.11.4",
     "moment": "^2.26.0",
@@ -77,6 +78,5 @@
     "serverless": "^1.70.1",
     "serverless-plugin-metric": "^1.2.2",
     "start-server-and-test": "^1.11.0"
-  },
-  "license" : "MIT"
+  }
 }

--- a/pages/referrals/status/[id].js
+++ b/pages/referrals/status/[id].js
@@ -8,6 +8,7 @@ import StatusForm from 'components/Feature/StatusForm';
 import Head from 'next/head';
 import { convertIsoDateToDateTimeString } from 'lib/utils/date';
 import { sendDataToAnalytics } from 'lib/utils/analytics';
+import { encode } from 'html-entities';
 
 const StatusHistory = ({ referral }) => {
   const { updateReferralStatus } = useReferral(null, {});
@@ -73,9 +74,11 @@ const StatusHistory = ({ referral }) => {
           <h1 className="govuk-heading-m" data-testid="status-paragraph">
             This referral was {recentStatus.status} on{' '}
             {convertIsoDateToDateTimeString(new Date(recentStatus.date))}
-            {recentStatus.comment && ` with comment: "${recentStatus.comment}".`}
+            {recentStatus.comment && ` with comment: "${encode(recentStatus.comment)}".`}
           </h1>
-          <p className="govuk-hint" data-testid="reference-number-paragraph">Reference number: {referral.referenceNumber}</p>
+          <p className="govuk-hint" data-testid="reference-number-paragraph">
+            Reference number: {referral.referenceNumber}
+          </p>
         </>
       ) : (
         <StatusForm

--- a/yarn.lock
+++ b/yarn.lock
@@ -6369,6 +6369,11 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-entities@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.2.tgz#760b404685cb1d794e4f4b744332e3b00dcfe488"
+  integrity sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"


### PR DESCRIPTION
**What**  
html encode the comment using html-entities package before displaying on screen
Before:
![image](https://user-images.githubusercontent.com/54268893/127145509-85665f3d-4a86-483d-9e57-9182de281cd6.png)

After:
<img width="1221" alt="image" src="https://user-images.githubusercontent.com/54268893/127145539-e752773f-c38e-4fe8-a19b-608043204134.png">


**Why**  
To reduce a possibility for XSS attacks

**Anything else?**  
 Add html-entities package
Removed license from package.json - we already specify it on line 4