### PR TITLE
Accessibility fixes

### DIFF
--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -140,31 +140,34 @@ const ResourceCard = ({
         <div className={`govuk-grid-row`}>
           <div className={`govuk-grid-column-one-half`}>
             <div className={`govuk-checkboxes__item ${css['inline-header']}`}>
-              <input
-                className="govuk-checkboxes__input"
-                id={`add-to-summary-checkbox-${resource.id}-${categoryId}`}
-                name="add-to-summary-checkbox"
-                type="checkbox"
-                onClick={() => {
-                  updateSignpostSummary({
-                    id: resource.id,
-                    name: resource.name,
-                    telephone: resource.telephone,
-                    contactEmail: resource.email,
-                    referralEmail: resource.referralContact,
-                    address: resource.address,
-                    websites: resource.websites.join(', '),
-                    categoryName: resource.categoryName
-                  });
-                }}
-                value={true}
-                checked={signpostSummary?.some(x => x.name == resource.name)}
-              />
-              <label
-                className={`govuk-label govuk-checkboxes__label ${css['checkbox-label']}`}
-                htmlFor={`add-to-summary-checkbox-${resource.id}-${categoryId}`}>
-                Share service with a resident
-              </label>
+              <fieldset className="govuk-fieldset" role="group">
+                <input
+                  className="govuk-checkboxes__input"
+                  id={`add-to-summary-checkbox-${resource.id}-${categoryId}`}
+                  name="add-to-summary-checkbox"
+                  type="checkbox"
+                  onClick={() => {
+                    updateSignpostSummary({
+                      id: resource.id,
+                      name: resource.name,
+                      telephone: resource.telephone,
+                      contactEmail: resource.email,
+                      referralEmail: resource.referralContact,
+                      address: resource.address,
+                      websites: resource.websites.join(', '),
+                      categoryName: resource.categoryName
+                    });
+                  }}
+                  value={true}
+                  checked={signpostSummary?.some(x => x.name == resource.name)}
+                />
+                <label
+                  className={`govuk-label govuk-checkboxes__label ${css['checkbox-label']}`}
+                  htmlFor={`add-to-summary-checkbox-${resource.id}-${categoryId}`}>
+                  Share service with a resident
+                </label>
+                <legend hidden>Share service with a resident</legend>
+              </fieldset>
             </div>
           </div>
           <div>

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -9,6 +9,8 @@ import {
   VIEW_SUMMARY_EMAIL_CLICKED
 } from 'lib/utils/constants';
 import ReferralForm from 'components/Feature/ReferralForm';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 
 const ResourceCard = ({
   updateSelectedResources,
@@ -81,20 +83,23 @@ const ResourceCard = ({
             className={`govuk-grid-column-two-thirds header-container ${css['header-container']}`}>
             <h3 data-testid="resource-card-header">
               {resource.websites?.length > 0 ? (
-                <a
-                  key={`website-link-${resource.websites[0]}`}
-                  href={resource.websites[0]}
-                  target="_blank"
-                  onClick={() => {
-                    sendDataToAnalytics({
-                      action: getUserGroup(referrerData['user-groups']),
-                      category: SERVICE_CLICK_WEBSITE,
-                      label: resource.name
-                    });
-                  }}
-                  rel="noopener noreferrer">
-                  {resource.name}
-                </a>
+                <>
+                  <a
+                    key={`website-link-${resource.websites[0]}`}
+                    href={resource.websites[0]}
+                    target="_blank"
+                    onClick={() => {
+                      sendDataToAnalytics({
+                        action: getUserGroup(referrerData['user-groups']),
+                        category: SERVICE_CLICK_WEBSITE,
+                        label: resource.name
+                      });
+                    }}
+                    rel="noopener noreferrer">
+                    {resource.name}
+                  </a>{' '}
+                  <FontAwesomeIcon icon={faExternalLinkAlt} transform="shrink-6" />
+                </>
               ) : (
                 resource.name
               )}

--- a/components/Form/Details/index.js
+++ b/components/Form/Details/index.js
@@ -10,9 +10,7 @@ const Details = ({ color, children, title, onclick, id }) => (
       style={color && { color: `${color}` }}
       id={`summary-${id}`}
       onClick={onclick}>
-      <span id={`span-${id}`} className="govuk-details__summary-text">
-        {title}
-      </span>
+      <span id={`span-${id}`}>{title}</span>
     </summary>
     <div className={`govuk-details__text ${css['lbh-details__text']}`}>{children}</div>
   </details>

--- a/components/Layout/Header/index.js
+++ b/components/Layout/Header/index.js
@@ -6,11 +6,9 @@ const Header = ({ serviceName }) => (
     <div
       className={`govuk-header__container govuk-width-container ${css['lbh-header__container']}`}>
       <div className="govuk-header__logo">
-        <a href="/" className="govuk-header__link govuk-header__link--homepage">
-          <span className={`govuk-header__logotype ${css['lbh-header__logotype']}`}>
-            <HackneyLogo />
-          </span>
-        </a>
+        <span className={`govuk-header__logotype ${css['lbh-header__logotype']}`}>
+          <HackneyLogo />
+        </span>
       </div>
       <div className="govuk-header__content">
         <a href="/" className="govuk-header__link govuk-header__link--service-name">

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,7 +5,6 @@ import './stylesheets/all.scss';
 export default class MyApp extends App {
   componentDidMount = () => {
     window.GOVUKFrontend.initAll();
-    document.getElementsByTagName('noscript')[0].remove();
   };
 
   render() {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,7 @@ import './stylesheets/all.scss';
 export default class MyApp extends App {
   componentDidMount = () => {
     window.GOVUKFrontend.initAll();
+    document.getElementsByTagName('noscript')[0].remove();
   };
 
   render() {

--- a/pages/index.js
+++ b/pages/index.js
@@ -144,7 +144,7 @@ Index.getInitialProps = async ({ req: { headers }, res }) => {
         (taxonomy.resources = resources.filter(resource => taxonomy.name == resource.categoryName))
     );
 
-    const errors = [otherResources.error].concat(fssErrors);
+    const errors = [otherResources.error].concat(fssErrors).filter(x => x);
 
     return {
       categorisedResources,


### PR DESCRIPTION
**What**  
Remove accessibility issues discovered in accessibility assessment:
- Remove underline from non-link text
<img width="293" alt="image" src="https://user-images.githubusercontent.com/54268893/127301685-86641669-bacd-4185-bb9f-ed6d36002a7b.png">
<img width="664" alt="image" src="https://user-images.githubusercontent.com/54268893/127301710-da28e343-2816-49b3-ac8a-879331b8714f.png">

- Remove redundant link from hackney logo as there was also a link on `Support for Hackney residents` header
- Filter out empty error messages before displaying them as they were displaying as empty `span` elements and were being suggested as h1-h6 elements.
- Add fieldset to `share service with a resident` checkboxes
- Add external link icon
<img width="587" alt="image" src="https://user-images.githubusercontent.com/54268893/127301638-fa2625bc-8b85-4b72-9a34-9afe42267ca9.png">


[BC2-62](https://hackney.atlassian.net/browse/BC2-62?atlOrigin=eyJpIjoiYjk5MGJkMDk3YTNiNGVhZmEzODI4ODM2OWVjNmIwNTciLCJwIjoiaiJ9)

**Why**  
To make the tool more accessible

**Anything else?**  
Accessibility recommendations included removing noscript tag, but by doing that the UI tests get stuck when running on circle, so left the noscript tag in as it's empty and isn't a severe violation
<img width="348" alt="image" src="https://user-images.githubusercontent.com/54268893/127302905-45ee69b0-e3df-4db5-a031-2ef28c58bb44.png">

