### PR TITLE
Check if synonyms env var is JSON before parsing it

### DIFF
--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -1,8 +1,9 @@
 import { normalise } from './normalise';
 import { removeCommonWords, getSearchableFields } from 'lib/utils/searchHelper';
-const synonyms = JSON.parse(process.env.SYNONYMS || '{}');
 
 const getSearchResults = (searchTerm, items) => {
+  const synonyms = isJSON(process.env.SYNONYMS) ? JSON.parse(process.env.SYNONYMS) : '{}';
+
   let normalisedSearchTerm = normalise(searchTerm.trim());
   let words = removeCommonWords(normalisedSearchTerm.split(' '));
 
@@ -10,7 +11,7 @@ const getSearchResults = (searchTerm, items) => {
     item.resources = item.resources
       .map(resource => {
         const resourceIndex = Object.values(getSearchableFields(resource));
-        resource.weight = getWeight(normalisedSearchTerm, words, resourceIndex);
+        resource.weight = getWeight(normalisedSearchTerm, words, resourceIndex, synonyms);
         return resource;
       })
       .filter(x => x.weight > 0);
@@ -19,7 +20,7 @@ const getSearchResults = (searchTerm, items) => {
   });
 };
 
-const getWeight = (searchTerm, words, resourceIndex) => {
+const getWeight = (searchTerm, words, resourceIndex, synonyms) => {
   const foundSynonyms = words.map(word =>
     Object.keys(synonyms).filter(key => synonyms[key].includes(word))
   );
@@ -32,6 +33,16 @@ const getWeight = (searchTerm, words, resourceIndex) => {
   )
     return 25;
   return 0;
+};
+
+const isJSON = text => {
+  if (!text) return false;
+  try {
+    JSON.parse(text);
+  } catch (e) {
+    return false;
+  }
+  return true;
 };
 
 export { getSearchResults };


### PR DESCRIPTION
**What**  
Check if synonyms env var is JSON before parsing it
Create synonyms parameter inside the getSearchResults method, because isJSON method is not available before init.
Pass synonyms into getWeight method

**Why**  
To avoid the page crashing if SYNONYMS isn't a JSON
