### PR TITLE
remove console logs and add synonym matching on full phrase

### DIFF
--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -24,25 +24,26 @@ const getWeight = (searchTerm, words, resourceIndex, synonyms) => {
   const foundSynonyms = words.map(word =>
     Object.keys(synonyms).filter(key => synonyms[key].includes(word))
   );
+  const foundSynonymsFullPhrase = Object.keys(synonyms).filter(key =>
+    synonyms[key].includes(searchTerm)
+  );
   if (resourceIndex.some(x => x.includes(searchTerm))) return 100;
   if (words.some(word => resourceIndex.some(x => x.includes(word)))) return 50;
   if (
     foundSynonyms.some(synonymArray =>
       resourceIndex.some(x => synonymArray.some(synonym => x.includes(synonym)))
-    )
+    ) ||
+    resourceIndex.some(x => foundSynonymsFullPhrase.some(synonym => x.includes(synonym)))
   )
     return 25;
   return 0;
 };
 
 const isJSON = text => {
-  console.log('text to parse');
-  console.log(text);
   if (!text) return false;
   try {
     JSON.parse(text);
   } catch (e) {
-    console.log('failed to parse: ' + e);
     return false;
   }
   return true;


### PR DESCRIPTION
**What**  
Add synonym matching on full phrase

**Why**  
Previously if more than 1 word is entered in the search box it would try to find a synonym for each word only. Now it'll also try to find a synonym for a full phrase.