### PR TITLE
Improve search ordering

### DIFF
--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -10,7 +10,7 @@ const getSearchResults = (searchTerm, items) => {
     item.resources = item.resources
       .map(resource => {
         const resourceIndex = Object.values(getSearchableFields(resource));
-        resource.weight = getWeight(normalisedSearchTerm, words, resourceIndex);
+        resource.weight = getWeight(normalisedSearchTerm, words, resource, resourceIndex);
         return resource;
       })
       .filter(x => x.weight > 0);
@@ -19,19 +19,41 @@ const getSearchResults = (searchTerm, items) => {
   });
 };
 
-const getWeight = (searchTerm, words, resourceIndex) => {
+const getWeight = (searchTerm, words, resource, resourceIndex) => {
+  let weight = 0;
+
+  weight += getFullPhraseWeight(searchTerm, resourceIndex);
+  weight += getIndividualWordsWeight(words, resourceIndex);
+  weight += getSynonymsWeight(words, resourceIndex);
+
+  const canReferToService = resource.referralContact || resource.referralWebsite;
+
+  if (weight > 0 && canReferToService) weight += 50;
+
+  return weight;
+};
+
+const getFullPhraseWeight = (searchTerm, resourceIndex) => {
+  if (resourceIndex.some(x => x.includes(searchTerm))) return 75;
+  return 0;
+};
+
+const getIndividualWordsWeight = (words, resourceIndex) => {
+  let wordsMatchedInTitle = words.filter(word => resourceIndex[0].includes(word)).length;
+  let wordsMatched = words.filter(word => resourceIndex.some(x => x.includes(word))).length;
+  return wordsMatched * 25 + wordsMatchedInTitle * 25;
+};
+
+const getSynonymsWeight = (words, resourceIndex) => {
   const foundSynonyms = words.map(word =>
     Object.keys(synonyms).filter(key => synonyms[key].includes(word))
   );
-  if (resourceIndex.some(x => x.includes(searchTerm))) return 100;
-  if (words.some(word => resourceIndex.some(x => x.includes(word)))) return 50;
-  if (
-    foundSynonyms.some(synonymArray =>
-      resourceIndex.some(x => synonymArray.some(synonym => x.includes(synonym)))
-    )
-  )
-    return 25;
-  return 0;
+
+  let synonymsMatched = foundSynonyms.filter(synonymArray =>
+    resourceIndex.some(x => synonymArray.some(synonym => x.includes(synonym)))
+  ).length;
+
+  return synonymsMatched * 25;
 };
 
 export { getSearchResults };

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -8,7 +8,7 @@ const getSearchResults = (searchTerm, items) => {
   return JSON.parse(JSON.stringify(items)).map(item => {
     item.resources = item.resources
       .map(resource => {
-        const resourceIndex = Object.values(getSearchableFields(resource));
+        const resourceIndex = getSearchableFields(resource);
         resource.weight = getWeight(normalisedSearchTerm, words, resource, resourceIndex);
         return resource;
       })
@@ -33,25 +33,27 @@ const getWeight = (searchTerm, words, resource, resourceIndex) => {
 };
 
 const getFullPhraseWeight = (searchTerm, resourceIndex) => {
-  if (resourceIndex.some(x => x.includes(searchTerm))) return 75;
+  if (Object.values(resourceIndex).some(x => x.includes(searchTerm))) return 75;
   return 0;
 };
 
 const getIndividualWordsWeight = (words, resourceIndex) => {
-  const wordsMatchedInTitle = words.filter(word => resourceIndex[0].includes(word)).length;
-  const wordsMatched = words.filter(word => resourceIndex.some(x => x.includes(word))).length;
+  const resourceIndexValues = Object.values(resourceIndex);
+  const wordsMatchedInTitle = words.filter(word => resourceIndex.name.includes(word)).length;
+  const wordsMatched = words.filter(word => resourceIndexValues.some(x => x.includes(word))).length;
 
   return wordsMatched * 25 + wordsMatchedInTitle * 25;
 };
 
 const getSynonymsWeight = (words, resourceIndex, searchTerm) => {
   const synonyms = isJSON(process.env.SYNONYMS) ? JSON.parse(process.env.SYNONYMS) : '{}';
+  const resourceIndexValues = Object.values(resourceIndex);
 
   const foundSynonymsFullPhrase = Object.keys(synonyms).filter(key =>
     synonyms[key].includes(searchTerm)
   );
 
-  const fullPhraseSynonymsMatched = resourceIndex.filter(x =>
+  const fullPhraseSynonymsMatched = resourceIndexValues.filter(x =>
     foundSynonymsFullPhrase.some(synonym => x.includes(synonym))
   ).length;
 
@@ -62,7 +64,7 @@ const getSynonymsWeight = (words, resourceIndex, searchTerm) => {
   );
 
   const synonymsMatched = foundSynonyms.filter(synonymArray =>
-    resourceIndex.some(x => synonymArray.some(synonym => x.includes(synonym)))
+    resourceIndexValues.some(x => synonymArray.some(synonym => x.includes(synonym)))
   ).length;
 
   return synonymsMatched * 25;

--- a/lib/utils/search.test.js
+++ b/lib/utils/search.test.js
@@ -12,7 +12,7 @@ describe('search', () => {
           name: 'giant ostrich',
           description: 'Big Orc',
           demographic: 'Men, Women',
-          serviceDescription: 'zebra hybrid',
+          serviceDescription: 'zebra hybrid cake',
           tags: ['tag1', 'tag2']
         },
         {
@@ -23,7 +23,13 @@ describe('search', () => {
         {
           id: 3,
           name: 'I am not a service',
-          description: 'Find services'
+          description: 'Find services biscuit',
+          serviceDescription: 'Very good biscuit cheese vendor'
+        },
+        {
+          id: 4,
+          name: 'tasty cake',
+          description: 'likes lego biscuit'
         }
       ]
     }
@@ -50,7 +56,7 @@ describe('search', () => {
       const filteredServices = getSearchResults(searchText, allServices);
 
       expect(filteredServices[0].resources.length).toBe(1);
-      expect(filteredServices[0].resources[0].serviceDescription).toEqual(searchText);
+      expect(filteredServices[0].resources[0].serviceDescription).toContain(searchText);
     });
 
     it('returns items where the search text is found in demographics', () => {
@@ -149,13 +155,13 @@ describe('search', () => {
       const searchText = '';
       const filteredServices = getSearchResults(searchText, allServices);
 
-      expect(filteredServices[0].resources.length).toBe(3);
+      expect(filteredServices[0].resources.length).toBe(4);
     });
     it('returns everything if search term consists of whitespace only', () => {
       const searchText = '   ';
       const filteredServices = getSearchResults(searchText, allServices);
 
-      expect(filteredServices[0].resources.length).toBe(3);
+      expect(filteredServices[0].resources.length).toBe(4);
     });
   });
 
@@ -168,8 +174,28 @@ describe('search', () => {
         var fullMatchItem = filteredServices[0].resources.filter(x => x.id == 2)[0];
         var wordMatchItem = filteredServices[0].resources.filter(x => x.id == 3)[0];
 
-        expect(fullMatchItem.weight).toBe(100);
+        expect(fullMatchItem.weight).toBe(125);
         expect(wordMatchItem.weight).toBe(50);
+      });
+      it('weights a title match higher than a content match for individual words', () => {
+        const searchText = 'cake';
+        const filteredServices = getSearchResults(searchText, allServices);
+
+        var titleMatchItem = filteredServices[0].resources.filter(x => x.id == 4)[0];
+        var contentMatchItem = filteredServices[0].resources.filter(x => x.id == 1)[0];
+
+        expect(titleMatchItem.weight).toBe(125);
+        expect(contentMatchItem.weight).toBe(100);
+      });
+      it('gives a higher weight if multiple words are found compared to one word found', () => {
+        const searchText = 'biscuit cheese';
+        const filteredServices = getSearchResults(searchText, allServices);
+
+        var multipleMatchItem = filteredServices[0].resources.filter(x => x.id == 3)[0];
+        var singleMatchItem = filteredServices[0].resources.filter(x => x.id == 4)[0];
+
+        expect(multipleMatchItem.weight).toBe(125);
+        expect(singleMatchItem.weight).toBe(25);
       });
       it('returns only items with a weight higher than zero', () => {
         const searchText = 'sdjkfhdsjkfhsdkf';

--- a/lib/utils/searchHelper.js
+++ b/lib/utils/searchHelper.js
@@ -28,7 +28,8 @@ const commonWords = [
   'except',
   'is',
   'of',
-  'an'
+  'an',
+  'hackney'
 ];
 
 const removeCommonWords = words => {


### PR DESCRIPTION
**What**  
- Now adds weight cumulatively rather than ordering by IsFullMatch, IsSingleWordMatch, IsSynonymMatch
- Weights Title matches higher than content.
- Weights results with a referral option higher than those without.

**Why**  
In order to provide more relevant results at the top we have improved ordering by relevance.
