### PR TITLE
My view

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
             export NEXT_PUBLIC_API_URL=http://localhost:3000/api
             export NEXT_PUBLIC_ENV=test
             export SYNONYMS="{\"ostrich\":[\"testsynonym\"]}"
+            export JWT_SECRET=a-secure-signature
             yarn build
       - run:
           name: Run unit tests
@@ -101,6 +102,7 @@ jobs:
             export NEXT_PUBLIC_ENV=test
             export NEXT_PUBLIC_GTM_ID=xx
             export SYNONYMS="{\"ostrich\":[\"testsynonym\"]}"
+            export JWT_SECRET=a-secure-signature
             CYPRESS_CACHE_FOLDER=~/repo/cypress_cache yarn run int-test
       - store_artifacts:
           path: ~/repo/cypress/screenshots

--- a/components/Feature/OverviewBox/index.js
+++ b/components/Feature/OverviewBox/index.js
@@ -1,0 +1,14 @@
+import css from './index.module.scss';
+const OverviewBox = ({ number, label, id }) => {
+  return (
+    <div id={id} className="govuk-grid-column-one-third">
+      <div className={css.box}>
+        <span className={css.number}>{number}</span>
+        <br />
+        <span className={css.label}>{label}</span>
+      </div>
+    </div>
+  );
+};
+
+export default OverviewBox;

--- a/components/Feature/OverviewBox/index.module.scss
+++ b/components/Feature/OverviewBox/index.module.scss
@@ -1,0 +1,14 @@
+.box {
+  background-color: #dee0e2;
+  padding: 10px 10px 20px 10px;
+  margin-bottom: 50px;
+}
+
+.number {
+  font-size: 2rem;
+  padding-left: 10px;
+}
+.label {
+  font-size: 1.2rem;
+  padding-left: 10px;
+}

--- a/components/Feature/ReferralForm/index.js
+++ b/components/Feature/ReferralForm/index.js
@@ -82,7 +82,8 @@ const ReferralForm = ({
       serviceWebsite: e.target['service-websites'].value,
       serviceDescription: e.target['service-description'].value,
       sendResidentSms: e.target['resident-referral-sms'].checked,
-      sendResidentEmail: e.target['resident-referral-email'].checked
+      sendResidentEmail: e.target['resident-referral-email'].checked,
+      emailFromToken: referrerData['user-email-from-token']
     };
     const result = await createReferral(referral);
 

--- a/components/Feature/ReferralsTable/index.js
+++ b/components/Feature/ReferralsTable/index.js
@@ -11,10 +11,10 @@ const ReferralsTable = ({ referrals }) => {
       label: 'In Progress',
       class: 'sent'
     },
-    REJECTED: {
-      label: 'Approved',
-      class: 'approved'
-    }
+    ACCEPTED: {
+      label: 'Accepted',
+      class: 'accepted'
+    },
   };
 
   const getStatus = history => {
@@ -47,20 +47,21 @@ const ReferralsTable = ({ referrals }) => {
       <tbody className="govuk-table__body">
         {referrals.map((referral, index) => {
           return (
-            <tr className="govuk-table__row" key={`referrals-table_row-${index}`}>
-              <td className="govuk-table__cell">
-                <a href="#">{referral.referenceNumber}</a>
+            <tr className="govuk-table__row" key={`referrals-table_row-${index}`} data-testid="referrals-table-row">
+              <td className="govuk-table__cell" data-testid="referrals-table-recerence-number">
+                <a href="#">{referral.referenceNumber || `no ref`}</a>
               </td>
-              <td className="govuk-table__cell">
+              <td className="govuk-table__cell"  data-testid="referrals-table-resident-name">
                 {referral.resident.firstName} {referral.resident.lastName}
               </td>
-              <td className="govuk-table__cell ">{referral.service.name}</td>
-              <td className="govuk-table__cell ">
+              <td className="govuk-table__cell " data-testid="referrals-table-service-name">
+                {referral.service.name}</td>
+              <td className="govuk-table__cell " data-testid="referrals-table-date-created">
                 {convertIsoDateToString(new Date(referral.created))}
               </td>
-              <td className={`govuk-table__cell`}>
-                <span className={`${css[statuses[getStatus(referral.statusHistory)].class]}`}>
-                  {statuses[getStatus(referral.statusHistory)].label}
+              <td className={`govuk-table__cell`} data-testid="referrals-table-status">
+                <span className={`${css[statuses[getStatus(referral.statusHistory)]?.class]}`}>
+                  {statuses[getStatus(referral.statusHistory)]?.label || "no status"}
                 </span>
               </td>
             </tr>

--- a/components/Feature/ReferralsTable/index.js
+++ b/components/Feature/ReferralsTable/index.js
@@ -1,0 +1,74 @@
+import { convertIsoDateToString } from 'lib/utils/date';
+import css from './index.module.scss';
+
+const ReferralsTable = ({ referrals }) => {
+  const statuses = {
+    REJECTED: {
+      label: 'Rejected',
+      class: 'rejected'
+    },
+    SENT: {
+      label: 'In Progress',
+      class: 'sent'
+    },
+    REJECTED: {
+      label: 'Approved',
+      class: 'approved'
+    }
+  };
+
+  const getStatus = history => {
+    return history.sort((a, b) => {
+      return new Date(b.date) - new Date(a.date);
+    })[0].status;
+  };
+
+  return (
+    <table className="govuk-table">
+      <thead className="govuk-table__head">
+        <tr className="govuk-table__row">
+          <th scope="col" className="govuk-table__header">
+            Reference number
+          </th>
+          <th scope="col" className="govuk-table__header">
+            Person referred
+          </th>
+          <th scope="col" className="govuk-table__header">
+            Org referred to
+          </th>
+          <th scope="col" className="govuk-table__header">
+            Date
+          </th>
+          <th scope="col" className="govuk-table__header">
+            Status
+          </th>
+        </tr>
+      </thead>
+      <tbody className="govuk-table__body">
+        {referrals.map((referral, index) => {
+          return (
+            <tr className="govuk-table__row" key={`referrals-table_row-${index}`}>
+              <td className="govuk-table__cell">
+                <a href="#">{referral.referenceNumber}</a>
+              </td>
+              <td className="govuk-table__cell">
+                {referral.resident.firstName} {referral.resident.lastName}
+              </td>
+              <td className="govuk-table__cell ">{referral.service.name}</td>
+              <td className="govuk-table__cell ">
+                {convertIsoDateToString(new Date(referral.created))}
+              </td>
+              <td className={`govuk-table__cell`}>
+                <span className={`${css[statuses[getStatus(referral.statusHistory)].class]}`}>
+                  {statuses[getStatus(referral.statusHistory)].label}
+                </span>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
+export default ReferralsTable;

--- a/components/Feature/ReferralsTable/index.js
+++ b/components/Feature/ReferralsTable/index.js
@@ -28,7 +28,7 @@ const ReferralsTable = ({ referrals }) => {
       <thead className="govuk-table__head">
         <tr className="govuk-table__row">
           <th scope="col" className="govuk-table__header">
-            Reference number
+            Ref number
           </th>
           <th scope="col" className="govuk-table__header">
             Person referred
@@ -60,9 +60,9 @@ const ReferralsTable = ({ referrals }) => {
                 {convertIsoDateToString(new Date(referral.created))}
               </td>
               <td className={`govuk-table__cell`} data-testid="referrals-table-status">
-                <span className={`${css[statuses[getStatus(referral.statusHistory)]?.class]}`}>
+                <div className={`${css[statuses[getStatus(referral.statusHistory)]?.class]}`}>
                   {statuses[getStatus(referral.statusHistory)]?.label || "no status"}
-                </span>
+                </div>
               </td>
             </tr>
           );

--- a/components/Feature/ReferralsTable/index.js
+++ b/components/Feature/ReferralsTable/index.js
@@ -23,12 +23,12 @@ const ReferralsTable = ({ referrals }) => {
     })[0].status;
   };
 
-  return (
+return (<><p>Displaying {referrals.length} record(s)</p>
     <table className="govuk-table">
       <thead className="govuk-table__head">
         <tr className="govuk-table__row">
           <th scope="col" className="govuk-table__header">
-            Ref number
+            Ref ID
           </th>
           <th scope="col" className="govuk-table__header">
             Person referred
@@ -69,6 +69,7 @@ const ReferralsTable = ({ referrals }) => {
         })}
       </tbody>
     </table>
+    </>
   );
 };
 

--- a/components/Feature/ReferralsTable/index.js
+++ b/components/Feature/ReferralsTable/index.js
@@ -8,7 +8,7 @@ const ReferralsTable = ({ referrals }) => {
       class: 'rejected'
     },
     SENT: {
-      label: 'In Progress',
+      label: 'Pending',
       class: 'sent'
     },
     ACCEPTED: {

--- a/components/Feature/ReferralsTable/index.module.scss
+++ b/components/Feature/ReferralsTable/index.module.scss
@@ -2,7 +2,14 @@
   background-color: #d4351c;
   color: white;
 }
-.accepted {
+.sent {
   background-color: #1d70b8;
   color: white;
+}
+
+.sent,
+.rejected,
+.accepted {
+  padding: 4px 4px 4px 4px;
+  border: solid 1px black;
 }

--- a/components/Feature/ReferralsTable/index.module.scss
+++ b/components/Feature/ReferralsTable/index.module.scss
@@ -1,8 +1,8 @@
 .rejected {
-  background-color: red;
+  background-color: #d4351c;
   color: white;
 }
-.approved {
-  background-color: blue;
+.accepted {
+  background-color: #1d70b8;
   color: white;
 }

--- a/components/Feature/ReferralsTable/index.module.scss
+++ b/components/Feature/ReferralsTable/index.module.scss
@@ -1,0 +1,8 @@
+.rejected {
+  background-color: red;
+  color: white;
+}
+.approved {
+  background-color: blue;
+  color: white;
+}

--- a/config/tables/content/accepted.json
+++ b/config/tables/content/accepted.json
@@ -1,7 +1,10 @@
 {
   "id": { "S": "123" },
   "linkId": { "S": "4" },
-  "created": { "S": "2021-07-21T12:29:17.120Z" },
+  "created": { "S": "2021-07-24T12:29:17.120Z" },
+  "referredBy": { "S": "test@email.com" },
+  "resident": { "M": { "firstName": { "S": "other" }, "lastName": { "S": "name" } } },
+  "service": { "M": { "name": { "S": "service name 3" } } },
   "statusHistory": {
     "L": [
       {

--- a/config/tables/content/rejected.json
+++ b/config/tables/content/rejected.json
@@ -1,7 +1,11 @@
 {
   "id": { "S": "124" },
   "linkId": { "S": "3" },
-  "created": { "S": "2021-07-21T12:29:17.120Z" },
+  "referenceNumber": { "S": "ABC-1" },
+  "created": { "S": "2021-07-12T12:29:17.120Z" },
+  "referredBy": { "S": "test@email.com" },
+  "resident": { "M": { "firstName": { "S": "some" }, "lastName": { "S": "name" } } },
+  "service": { "M": { "name": { "S": "service name 2" } } },
   "statusHistory": {
     "L": [
       {

--- a/config/tables/content/sent.json
+++ b/config/tables/content/sent.json
@@ -2,7 +2,10 @@
   "id": { "S": "11" },
   "linkId": { "S": "1" },
   "referenceNumber": { "S": "E7UK-8" },
-  "created": { "S": "2021-07-21T12:29:17.120Z" },
+  "created": { "S": "2021-04-02T12:29:17.120Z" },
+  "referredBy": { "S": "test@email.com" },
+  "resident": { "M": { "firstName": { "S": "more" }, "lastName": { "S": "name" } } },
+  "service": { "M": { "name": { "S": "service name 1" } } },
   "statusHistory": {
     "L": [
       {

--- a/cypress/integration/pages/myView.spec.js
+++ b/cypress/integration/pages/myView.spec.js
@@ -1,0 +1,75 @@
+/// <reference types="cypress" />
+context('my view page', () => {
+  it('Shows a table with correct number of referrals', () => {
+    cy.setHackneyCookie(true);
+    cy.visit('/my-view');
+    cy.injectAxe();
+
+    cy.get('[data-testid=referrals-table-row]').should('have.length', '3');
+    cy.runCheckA11y();
+  });
+
+  it('shows newest referrals first', () => {
+    cy.get('[data-testid=referrals-table-recerence-number]')
+      .eq(0)
+      .should('contain', 'no ref');
+
+    cy.get('[data-testid=referrals-table-recerence-number]')
+      .eq(1)
+      .should('contain', 'ABC-1');
+
+    cy.get('[data-testid=referrals-table-recerence-number]')
+      .eq(2)
+      .should('contain', 'E7UK-8');
+  });
+
+  it('shows correct referral information', () => {
+    cy.get('[data-testid=referrals-table-resident-name]')
+      .eq(0)
+      .should('contain', 'other name');
+
+    cy.get('[data-testid=referrals-table-resident-name]')
+      .eq(1)
+      .should('contain', 'some name');
+
+    cy.get('[data-testid=referrals-table-resident-name]')
+      .eq(2)
+      .should('contain', 'more name');
+
+    cy.get('[data-testid=referrals-table-service-name]')
+      .eq(0)
+      .should('contain', 'service name 3');
+
+    cy.get('[data-testid=referrals-table-service-name]')
+      .eq(1)
+      .should('contain', 'service name 2');
+
+    cy.get('[data-testid=referrals-table-service-name]')
+      .eq(2)
+      .should('contain', 'service name 1');
+
+    cy.get('[data-testid=referrals-table-date-created]')
+      .eq(0)
+      .should('contain', '24/07/2021');
+
+    cy.get('[data-testid=referrals-table-date-created]')
+      .eq(1)
+      .should('contain', '12/07/2021');
+
+    cy.get('[data-testid=referrals-table-date-created]')
+      .eq(2)
+      .should('contain', '02/04/2021');
+
+    cy.get('[data-testid=referrals-table-status]')
+      .eq(0)
+      .should('contain', 'Accepted');
+
+    cy.get('[data-testid=referrals-table-status]')
+      .eq(1)
+      .should('contain', 'Rejected');
+
+    cy.get('[data-testid=referrals-table-status]')
+      .eq(2)
+      .should('contain', 'In Progress');
+  });
+});

--- a/cypress/integration/pages/myView.spec.js
+++ b/cypress/integration/pages/myView.spec.js
@@ -70,6 +70,6 @@ context('my view page', () => {
 
     cy.get('[data-testid=referrals-table-status]')
       .eq(2)
-      .should('contain', 'In Progress');
+      .should('contain', 'Pending');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,7 +46,10 @@ import jwt from 'jsonwebtoken';
 
 const setHackneyCookie = isValidGroup => {
   const group = isValidGroup ? 'housingneeds-singleview-beta' : 'some-other-group';
-  const token = jwt.sign({ name: 'My name', groups: [group] }, 'a-secure-signature');
+  const token = jwt.sign(
+    { name: 'My name', groups: [group], email: 'test@email.com' },
+    'a-secure-signature'
+  );
   cy.setCookie('hackneyToken', token, {
     url: 'http://localhost:3000',
     domain: 'localhost'

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -72,6 +72,6 @@ export function requestFssResources(options) {
   return request(`/resources/fss`, { method: 'GET', ...options });
 }
 
-export function findReferrals(referrerEmail, options) {
-  return request(`/referrals/find`, { method: 'POST', body: referrerEmail, ...options });
+export function findReferrals(findBy, options) {
+  return request(`/referrals/find`, { method: 'POST', body: { findBy }, ...options });
 }

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -71,3 +71,7 @@ export function requestResources(options) {
 export function requestFssResources(options) {
   return request(`/resources/fss`, { method: 'GET', ...options });
 }
+
+export function findReferrals(referrerEmail, options) {
+  return request(`/referrals/find`, { method: 'POST', body: referrerEmail, ...options });
+}

--- a/lib/domain/referral.js
+++ b/lib/domain/referral.js
@@ -53,8 +53,7 @@ export default class Referral {
       : {
           name: referrerName,
           organisation: referrerOrganisation,
-          email: referrerEmail,
-          emailFromToken
+          email: referrerEmail
         };
     this.referralReason = referralReason;
     this.conversationNotes = conversationNotes;
@@ -74,5 +73,6 @@ export default class Referral {
     this.linkId = linkId;
     this.referenceNumber = referenceNumber;
     this.statusHistory = statusHistory;
+    this.referredBy = emailFromToken;
   }
 }

--- a/lib/domain/referral.js
+++ b/lib/domain/referral.js
@@ -31,7 +31,8 @@ export default class Referral {
     id,
     linkId,
     referenceNumber,
-    statusHistory
+    statusHistory,
+    emailFromToken
   }) {
     this.id = id;
     this.emails = emails;
@@ -52,7 +53,8 @@ export default class Referral {
       : {
           name: referrerName,
           organisation: referrerOrganisation,
-          email: referrerEmail
+          email: referrerEmail,
+          emailFromToken
         };
     this.referralReason = referralReason;
     this.conversationNotes = conversationNotes;

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -83,7 +83,25 @@ class ReferralGateway {
     return createReferralFromModel(result.Items[0]);
   }
 
-  async find({ firstName, lastName, systemIds }) {
+  async find({ firstName, lastName, systemIds, referrerEmail }) {
+    if (referrerEmail) {
+      console.log(`Find endpoint called with: ${referrerEmail}`);
+      const request = {
+        TableName: this.tableName,
+        ProjectionExpression:
+          'id, firstName, lastName, statusHistory, referenceNumber, referrer, resident, service',
+        FilterExpression: 'referredBy = :referredBy',
+        ExpressionAttributeValues: {
+          ':referredBy': referrerEmail
+        }
+      };
+
+      const result = await this.client.scan(request).promise();
+      if (result.Items.length === 0) return [];
+
+      return result.Items.map(item => createReferralFromModel(item));
+    }
+
     if (!firstName) throw new ArgumentError('first name cannot be null.');
     if (!lastName) throw new ArgumentError('last name cannot be null.');
 

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -90,7 +90,7 @@ class ReferralGateway {
     const request = {
       TableName: this.tableName,
       ProjectionExpression:
-        'id, firstName, lastName, statusHistory, referenceNumber, referrer, resident, service',
+        'id, firstName, lastName, statusHistory, referenceNumber, referrer, resident, service, created',
       FilterExpression: 'referredBy = :referredBy',
       ExpressionAttributeValues: {
         ':referredBy': referrerEmail

--- a/lib/gateways/referral-gateway.js
+++ b/lib/gateways/referral-gateway.js
@@ -83,60 +83,28 @@ class ReferralGateway {
     return createReferralFromModel(result.Items[0]);
   }
 
-  async find({ firstName, lastName, systemIds, referrerEmail }) {
-    if (referrerEmail) {
-      console.log(`Find endpoint called with: ${referrerEmail}`);
-      const request = {
-        TableName: this.tableName,
-        ProjectionExpression:
-          'id, firstName, lastName, statusHistory, referenceNumber, referrer, resident, service',
-        FilterExpression: 'referredBy = :referredBy',
-        ExpressionAttributeValues: {
-          ':referredBy': referrerEmail
-        }
-      };
+  async find({ referrerEmail }) {
+    if (!referrerEmail) throw new ArgumentError('referrer email cannot be null.');
 
-      const result = await this.client.scan(request).promise();
-      if (result.Items.length === 0) return [];
-
-      return result.Items.map(item => createReferralFromModel(item));
-    }
-
-    if (!firstName) throw new ArgumentError('first name cannot be null.');
-    if (!lastName) throw new ArgumentError('last name cannot be null.');
-
-    console.log(`Find endpoint called with: ${firstName} ${lastName} ${systemIds}`);
+    console.log(`Find endpoint called with: ${referrerEmail}`);
     const request = {
       TableName: this.tableName,
-      IndexName: 'NamesIndex',
-      KeyConditionExpression: 'queryLastName = :l and queryFirstName = :f',
+      ProjectionExpression:
+        'id, firstName, lastName, statusHistory, referenceNumber, referrer, resident, service',
+      FilterExpression: 'referredBy = :referredBy',
       ExpressionAttributeValues: {
-        ':l': lastName.toLowerCase(),
-        ':f': firstName.toLowerCase()
+        ':referredBy': referrerEmail
       }
     };
 
-    const { Items } = await this.client.query(request).promise();
-    console.log('Find endpoint has found: ', Items);
-
-    const matchBySystemId = s => {
-      if (!s.systemIds || s.systemIds.length === 0) return true;
-      return s.systemIds.some(id => systemIds.includes(id));
-    };
-    const matches = Items.filter(matchBySystemId);
-
-    // because we're using a GSI to find, we need to then do a get
-    // on each match to get the full data model back
-    const referrals = await Promise.all(matches.map(m => this.get(m)));
-
-    const filterEmptyReferrals = s =>
-      s.vulnerabilities.length > 0 || s.assets.length > 0 || s.notes.length > 0;
-
+    const result = await this.client.scan(request).promise();
+    if (result.Items.length === 0) return [];
     const sortReferralsByCreateDate = (s1, s2) => (s1.created < s2.created ? 1 : -1);
 
-    return {
-      referrals: referrals.filter(filterEmptyReferrals).sort(sortReferralsByCreateDate)
-    };
+    const referrals = result.Items.map(item => createReferralFromModel(item)).sort(
+      sortReferralsByCreateDate
+    );
+    return { referrals };
   }
 
   async update({ referral }) {

--- a/lib/gateways/referral-gateway.test.js
+++ b/lib/gateways/referral-gateway.test.js
@@ -13,7 +13,8 @@ describe('ReferralGateway', () => {
         promise: jest.fn(() => ({ Items: [request.Item] }))
       })),
       query: jest.fn(() => ({ promise: jest.fn() })),
-      update: jest.fn(() => ({ promise: jest.fn() }))
+      update: jest.fn(() => ({ promise: jest.fn() })),
+      scan: jest.fn(() => ({ promise: jest.fn() }))
     };
   });
 
@@ -152,111 +153,61 @@ describe('ReferralGateway', () => {
   });
 
   describe('find', () => {
-    it('throws an error if first name is missing', async () => {
+    it('throws an error if referrer email is missing', async () => {
       const referralGateway = new ReferralGateway({ client, tableName });
 
       await expect(async () => {
         await referralGateway.find({});
-      }).rejects.toThrow('first name cannot be null.');
+      }).rejects.toThrow('referrer email cannot be null.');
       expect(client.query).not.toHaveBeenCalled();
     });
 
-    it('throws an error if last name is missing', async () => {
-      const referralGateway = new ReferralGateway({ client, tableName });
-
-      await expect(async () => {
-        await referralGateway.find({ firstName: 'Linda' });
-      }).rejects.toThrow('last name cannot be null.');
-      expect(client.query).not.toHaveBeenCalled();
-    });
-
-    it('can find matching referrals by name', async () => {
-      const firstName = 'Sister';
-      const lastName = 'Nancy';
-      client.query = jest.fn(() => ({
+    it('can find matching referrals by email', async () => {
+      client.scan = jest.fn(() => ({
         promise: jest.fn(() => ({ Items: [{}] }))
       }));
       const referralGateway = new ReferralGateway({ client, tableName });
       const expectedRequest = {
         TableName: tableName,
-        IndexName: 'NamesIndex',
-        KeyConditionExpression: 'queryLastName = :l and queryFirstName = :f',
+        FilterExpression: 'referredBy = :referredBy',
+        ProjectionExpression:
+          'id, firstName, lastName, statusHistory, referenceNumber, referrer, resident, service',
         ExpressionAttributeValues: {
-          ':f': firstName.toLowerCase(),
-          ':l': lastName.toLowerCase()
+          ':referredBy': 'email'
         }
       };
-      referralGateway.get = jest.fn(() => {
-        return { assets: [], vulnerabilities: [], notes: '' };
-      });
+      // referralGateway.get = jest.fn(() => {
+      //   return {};
+      // });
 
       await referralGateway.find({
-        firstName,
-        lastName
+        referrerEmail: 'email'
       });
 
-      expect(client.query).toHaveBeenCalledWith(expectedRequest);
-    });
-
-    it('filters referrals using system ids', async () => {
-      const systemId = 'HH123456';
-      client.query.mockImplementation(() => {
-        return {
-          promise: () =>
-            Promise.resolve({
-              Items: [
-                { id: '1', systemIds: ['xxxxxx'] },
-                { id: '2', systemIds: [systemId] }
-              ]
-            })
-        };
-      });
-      const referralGateway = new ReferralGateway({ client, tableName });
-      referralGateway.get = jest.fn(async s => {
-        return {
-          id: s.id,
-          systemIds: s.systemIds,
-          assets: [{}],
-          vulnerabilities: [],
-          notes: ''
-        };
-      });
-
-      const result = await referralGateway.find({
-        firstName: 'Hey',
-        lastName: 'Hey',
-        systemIds: [systemId]
-      });
-
-      expect(result.referrals.length).toEqual(1);
-      expect(result.referrals[0].systemIds).toEqual([systemId]);
+      expect(client.scan).toHaveBeenCalledWith(expectedRequest);
     });
 
     it('sorts referrals by date descending', async () => {
-      const systemId = 'matching';
-      client.query.mockImplementation(() => {
+      // const systemId = 'matching';
+      client.scan.mockImplementation(() => {
         return {
           promise: () =>
             Promise.resolve({
               Items: [
                 {
                   id: 3,
-                  systemIds: [systemId],
                   created: '2022-10-20T00:00:00.000Z'
                 },
                 {
                   id: 4,
-                  systemIds: [systemId],
                   created: '2022-10-20T00:15:00.000Z'
                 },
                 {
                   id: 1,
-                  systemIds: [systemId],
                   created: '2022-09-18T00:00:00.000Z'
                 },
                 {
                   id: 2,
-                  systemIds: [systemId],
                   created: '2022-09-19T00:00:00.000Z'
                 }
               ]
@@ -264,21 +215,15 @@ describe('ReferralGateway', () => {
         };
       });
       const referralGateway = new ReferralGateway({ client, tableName });
-      referralGateway.get = jest.fn(async s => {
-        return {
-          id: s.id,
-          created: s.created,
-          systemIds: s.systemIds,
-          assets: [{}],
-          vulnerabilities: [],
-          notes: ''
-        };
-      });
+      // referralGateway.get = jest.fn(async s => {
+      //   return {
+      //     id: s.id,
+      //     created: s.created,
+      //   };
+      // });
 
       const result = await referralGateway.find({
-        firstName: 'Hey',
-        lastName: 'Hey',
-        systemIds: [systemId]
+        referrerEmail: 'email'
       });
 
       expect(result.referrals[0].id).toEqual(4);
@@ -287,68 +232,17 @@ describe('ReferralGateway', () => {
       expect(result.referrals[3].id).toEqual(1);
     });
 
-    it('filters empty referrals', async () => {
-      const systemId = 'matching';
-      client.query.mockImplementation(() => {
-        return {
-          promise: () =>
-            Promise.resolve({
-              Items: [
-                {
-                  id: 3,
-                  systemIds: [systemId],
-                  vulnerabilities: []
-                },
-                {
-                  id: 4,
-                  systemIds: [systemId],
-                  vulnerabilities: [{}]
-                }
-              ]
-            })
-        };
-      });
-      const referralGateway = new ReferralGateway({ client, tableName });
-      referralGateway.get = jest.fn(async s => {
-        return {
-          id: s.id,
-          systemIds: s.systemIds,
-          assets: [],
-          vulnerabilities: s.vulnerabilities,
-          notes: ''
-        };
-      });
-
-      const result = await referralGateway.find({
-        firstName: 'Hey',
-        lastName: 'Hey',
-        systemIds: [systemId]
-      });
-      expect(result).toEqual({
-        referrals: [
-          {
-            id: 4,
-            systemIds: [systemId],
-            assets: [],
-            vulnerabilities: [{}],
-            notes: ''
-          }
-        ]
-      });
-    });
-
     it('returns empty array when no matching referrals', async () => {
-      client.query = jest.fn(() => ({
+      client.scan = jest.fn(() => ({
         promise: jest.fn(() => ({ Items: [] }))
       }));
       const referralGateway = new ReferralGateway({ client, tableName });
 
       const result = await referralGateway.find({
-        firstName: 'Janos',
-        lastName: 'Manos'
+        referrerEmail: 'Janos@mail.zz'
       });
 
-      expect(result).toEqual({ referrals: [] });
+      expect(result).toEqual([]);
     });
   });
 

--- a/lib/gateways/referral-gateway.test.js
+++ b/lib/gateways/referral-gateway.test.js
@@ -171,7 +171,7 @@ describe('ReferralGateway', () => {
         TableName: tableName,
         FilterExpression: 'referredBy = :referredBy',
         ProjectionExpression:
-          'id, firstName, lastName, statusHistory, referenceNumber, referrer, resident, service',
+          'id, firstName, lastName, statusHistory, referenceNumber, referrer, resident, service, created',
         ExpressionAttributeValues: {
           ':referredBy': 'email'
         }

--- a/lib/use-cases/find-referrals.js
+++ b/lib/use-cases/find-referrals.js
@@ -1,5 +1,5 @@
 import { getTokenFromCookieHeader } from 'lib/utils/token';
-import jsonwebtoken from 'jsonwebtoken';
+import CheckAuth from 'router/use-cases/check-auth';
 
 export default class FindReferrals {
   constructor({ referralGateway }) {
@@ -9,7 +9,9 @@ export default class FindReferrals {
   async execute(request, cookie) {
     if (request.findBy == 'referrerEmail') {
       const token = getTokenFromCookieHeader({ cookie });
-      const { email } = jsonwebtoken.decode(token);
+
+      const checkAuth = new CheckAuth({});
+      const email = checkAuth.getEmail(token);
 
       console.log('Looking for referrals with request: ', request, ': ', email);
       return await this.referralGateway.find({ referrerEmail: email });

--- a/lib/use-cases/find-referrals.js
+++ b/lib/use-cases/find-referrals.js
@@ -1,10 +1,19 @@
+import { getTokenFromCookieHeader } from 'lib/utils/token';
+import jsonwebtoken from 'jsonwebtoken';
+
 export default class FindReferrals {
   constructor({ referralGateway }) {
     this.referralGateway = referralGateway;
   }
 
-  async execute(request) {
-    console.log('Looking for referrals with request: ', request);
-    return await this.referralGateway.find(request);
+  async execute(request, cookie) {
+    if (request.findBy == 'referrerEmail') {
+      const token = getTokenFromCookieHeader({ cookie });
+      const { email } = jsonwebtoken.decode(token);
+
+      console.log('Looking for referrals with request: ', request, ': ', email);
+      return await this.referralGateway.find({ referrerEmail: email });
+    }
+    return [];
   }
 }

--- a/lib/use-cases/find-referrals.test.js
+++ b/lib/use-cases/find-referrals.test.js
@@ -1,17 +1,18 @@
 import FindReferrals from 'lib/use-cases/find-referrals';
+import jwt from 'jsonwebtoken';
+jest.mock('jsonwebtoken');
 
 describe('Find Referrals use case', () => {
   it('can find matching referrals', async () => {
     const referralGateway = { find: jest.fn() };
     const findReferrals = new FindReferrals({ referralGateway });
+    jwt.decode.mockReturnValue({ email: 'mock' });
 
     const findReferralsRequest = {
-      firstName: 'Joe',
-      lastName: 'Bro',
-      systemIds: ['123']
+      findBy: 'referrerEmail'
     };
 
-    await findReferrals.execute(findReferralsRequest);
-    expect(referralGateway.find).toHaveBeenCalledWith(findReferralsRequest);
+    await findReferrals.execute(findReferralsRequest, 'abc');
+    expect(referralGateway.find).toHaveBeenCalledWith({ referrerEmail: 'mock' });
   });
 });

--- a/lib/use-cases/find-referrals.test.js
+++ b/lib/use-cases/find-referrals.test.js
@@ -6,13 +6,13 @@ describe('Find Referrals use case', () => {
   it('can find matching referrals', async () => {
     const referralGateway = { find: jest.fn() };
     const findReferrals = new FindReferrals({ referralGateway });
-    jwt.decode.mockReturnValue({ email: 'mock' });
+    jwt.verify.mockReturnValue({ email: 'mock' });
 
     const findReferralsRequest = {
       findBy: 'referrerEmail'
     };
 
-    await findReferrals.execute(findReferralsRequest, 'abc');
+    await findReferrals.execute(findReferralsRequest, 'hackneyToken=abc');
     expect(referralGateway.find).toHaveBeenCalledWith({ referrerEmail: 'mock' });
   });
 });

--- a/pages/api/referrals/find/index.js
+++ b/pages/api/referrals/find/index.js
@@ -8,16 +8,14 @@ export const endpoint = ({ findReferrals }) =>
       allowedMethods: ['POST'],
       validators: [
         {
-          name: 'referrerEmail',
-          failureMessage: 'referrerEmailis required',
-          validate: ({ body }) => body.referrerEmail && body.referrerEmail.length > 0
+          name: 'findBy',
+          failureMessage: 'findBy is required',
+          validate: ({ body }) => body.findBy && ['referrerEmail'].includes(body.findBy)
         }
       ]
     },
-    async ({ body: { referrerEmail } }) => {
-      const result = await findReferrals.execute({
-        referrerEmail
-      });
+    async ({ body: { findBy }, headers }) => {
+      const result = await findReferrals.execute({ findBy }, headers.cookie);
       return Response.ok(result);
     }
   );

--- a/pages/api/referrals/find/index.js
+++ b/pages/api/referrals/find/index.js
@@ -5,25 +5,14 @@ import { findReferrals } from 'lib/dependencies';
 export const endpoint = ({ findReferrals }) =>
   createEndpoint(
     {
-      allowedMethods: ['POST'],
-      validators: [
-        {
-          name: 'firstName',
-          failureMessage: 'first name is required',
-          validate: ({ body }) => body.firstName?.length > 0
-        },
-        {
-          name: 'lastName',
-          failureMessage: 'last name is required',
-          validate: ({ body }) => body.lastName?.length > 0
-        }
-      ]
+      allowedMethods: ['POST']
     },
-    async ({ body: { firstName, lastName, systemIds } }) => {
+    async ({ body: { firstName, lastName, systemIds, referrerEmail } }) => {
       const result = await findReferrals.execute({
         firstName,
         lastName,
-        systemIds
+        systemIds,
+        referrerEmail
       });
       return Response.ok(result);
     }

--- a/pages/api/referrals/find/index.js
+++ b/pages/api/referrals/find/index.js
@@ -5,13 +5,17 @@ import { findReferrals } from 'lib/dependencies';
 export const endpoint = ({ findReferrals }) =>
   createEndpoint(
     {
-      allowedMethods: ['POST']
+      allowedMethods: ['POST'],
+      validators: [
+        {
+          name: 'referrerEmail',
+          failureMessage: 'referrerEmailis required',
+          validate: ({ body }) => body.referrerEmail && body.referrerEmail.length > 0
+        }
+      ]
     },
-    async ({ body: { firstName, lastName, systemIds, referrerEmail } }) => {
+    async ({ body: { referrerEmail } }) => {
       const result = await findReferrals.execute({
-        firstName,
-        lastName,
-        systemIds,
         referrerEmail
       });
       return Response.ok(result);

--- a/pages/api/referrals/find/index.test.js
+++ b/pages/api/referrals/find/index.test.js
@@ -16,14 +16,9 @@ describe('Find Referrals Api', () => {
   };
 
   it('can find referrals', async () => {
-    const firstName = 'sue';
-    const lastName = 'taylor';
-    const systemIds = ['xyz'];
-    const response = await call({ body: { firstName, lastName, systemIds } });
+    const response = await call({ body: { referrerEmail: 'email' } });
     expect(findReferrals.execute).toHaveBeenCalledWith({
-      firstName,
-      lastName,
-      systemIds
+      referrerEmail: 'email'
     });
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual(JSON.stringify({ referralIds: [1, 2] }));
@@ -35,23 +30,9 @@ describe('Find Referrals Api', () => {
   });
 
   describe('validation', () => {
-    it('returns 400 when no firstName', async () => {
+    it('returns 400 when no referrerEmail', async () => {
       const response = await call({
-        body: {
-          lastName: 'taylor',
-          systemIds: ['xyz']
-        }
-      });
-      expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.body).errors.length).toBe(1);
-    });
-
-    it('returns 400 when no lastName', async () => {
-      const response = await call({
-        body: {
-          firstName: 'sue',
-          systemIds: ['xyz']
-        }
+        body: {}
       });
       expect(response.statusCode).toBe(400);
       expect(JSON.parse(response.body).errors.length).toBe(1);
@@ -64,9 +45,7 @@ describe('Find Referrals Api', () => {
     });
     const response = await call({
       body: {
-        firstName: 'sue',
-        lastName: 'taylor',
-        systemIds: ['xyz']
+        referrerEmail: 'sue'
       }
     });
     expect(response.statusCode).toBe(500);

--- a/pages/api/referrals/find/index.test.js
+++ b/pages/api/referrals/find/index.test.js
@@ -3,12 +3,13 @@ import createMockResponse from 'lib/api/utils/createMockResponse';
 
 describe('Find Referrals Api', () => {
   const findReferrals = { execute: jest.fn(() => ({ referralIds: [1, 2] })) };
-  const call = async ({ method, body }) => {
+  const call = async ({ method, body, headers }) => {
     const response = createMockResponse();
     await endpoint({ findReferrals })(
       {
         method: method || 'POST',
-        body
+        body,
+        headers
       },
       response
     );
@@ -16,10 +17,17 @@ describe('Find Referrals Api', () => {
   };
 
   it('can find referrals', async () => {
-    const response = await call({ body: { referrerEmail: 'email' } });
-    expect(findReferrals.execute).toHaveBeenCalledWith({
-      referrerEmail: 'email'
+    const response = await call({
+      body: { findBy: 'referrerEmail' },
+      headers: { cookie: 'hackneyToken=abc' }
     });
+
+    expect(findReferrals.execute).toHaveBeenCalledWith(
+      {
+        findBy: 'referrerEmail'
+      },
+      'hackneyToken=abc'
+    );
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual(JSON.stringify({ referralIds: [1, 2] }));
   });
@@ -45,7 +53,7 @@ describe('Find Referrals Api', () => {
     });
     const response = await call({
       body: {
-        referrerEmail: 'sue'
+        findBy: 'referrerEmail'
       }
     });
     expect(response.statusCode).toBe(500);

--- a/pages/api/referrals/index.js
+++ b/pages/api/referrals/index.js
@@ -63,7 +63,8 @@ export const endpoint = ({ createReferral }) =>
         serviceWebsite,
         sendResidentSms,
         sendResidentEmail,
-        serviceDescription
+        serviceDescription,
+        emailFromToken
       },
       headers
     }) => {
@@ -88,7 +89,8 @@ export const endpoint = ({ createReferral }) =>
           serviceReferralEmail,
           serviceAddress,
           serviceWebsite,
-          serviceDescription
+          serviceDescription,
+          emailFromToken
         }),
         sendResidentSms,
         sendResidentEmail

--- a/pages/index.js
+++ b/pages/index.js
@@ -29,7 +29,8 @@ const Index = ({ categorisedResources, initialReferral, token, errors, refererIn
     'referer-organisation': refererInfo?.groups.includes(process.env.EXTERNAL_USER_GROUP)
       ? ''
       : 'Hackney Council',
-    'user-groups': refererInfo?.groups
+    'user-groups': refererInfo?.groups,
+    'user-email-from-token': refererInfo?.email
   });
   const [preserveFormData, setPreserveFormData] = useState(true);
 

--- a/pages/my-view/index.js
+++ b/pages/my-view/index.js
@@ -3,36 +3,15 @@ import HttpStatusError from 'lib/api/domain/HttpStatusError';
 import { getTokenFromCookieHeader } from 'lib/utils/token';
 import jsonwebtoken from 'jsonwebtoken';
 import Head from 'next/head';
-import { convertIsoDateToString } from 'lib/utils/date';
-import css from './index.module.scss';
+import ReferralsTable from 'components/Feature/ReferralsTable';
 const Index = ({ errors, referrerInfo, myReferrals }) => {
-  const statuses = {
-    REJECTED: {
-      label: 'Rejected',
-      class: 'rejected'
-    },
-    SENT: {
-      label: 'In Progress',
-      class: 'sent'
-    },
-    REJECTED: {
-      label: 'Approved',
-      class: 'approved'
-    }
-  };
-
-  const getStatus = history => {
-    return history.sort((a, b) => {
-      return new Date(b.date) - new Date(a.date);
-    })[0].status;
-  };
   return (
     <>
       <Head>
         <title>Better Conversations: My view</title>
       </Head>
       <h1 className="govuk-heading-l">My referrals</h1>
-
+      <hr className={`govuk-section-break govuk-section-break--m govuk-section-break--visible`} />
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-quarter">
           <ul class="govuk-list">
@@ -53,50 +32,7 @@ const Index = ({ errors, referrerInfo, myReferrals }) => {
 
         <div className="govuk-grid-column-three-quarters">
           <h2 className="govuk-heading-m">Historic referrals</h2>
-          <table className="govuk-table">
-            <thead className="govuk-table__head">
-              <tr className="govuk-table__row">
-                <th scope="col" className="govuk-table__header">
-                  Reference number
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Person referred
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Org referred to
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Date
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody className="govuk-table__body">
-              {myReferrals.map((referral, index) => {
-                return (
-                  <tr className="govuk-table__row" key={`referrals-table_row-${index}`}>
-                    <td className="govuk-table__cell">
-                      <a href="#">{referral.referenceNumber}</a>
-                    </td>
-                    <td className="govuk-table__cell">
-                      {referral.resident.firstName} {referral.resident.lastName}
-                    </td>
-                    <td className="govuk-table__cell ">{referral.service.name}</td>
-                    <td className="govuk-table__cell ">
-                      {convertIsoDateToString(new Date(referral.created))}
-                    </td>
-                    <td className={`govuk-table__cell`}>
-                      <span className={`${css[statuses[getStatus(referral.statusHistory)].class]}`}>
-                        {statuses[getStatus(referral.statusHistory)].label}
-                      </span>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <ReferralsTable referrals={myReferrals} />
         </div>
       </div>
     </>

--- a/pages/my-view/index.js
+++ b/pages/my-view/index.js
@@ -19,13 +19,15 @@ const Index = ({ errors, referrerInfo, myReferrals }) => {
               <a href="#">Team view</a>
             </li>
             <li>
-              <a href="#">My view</a>
+              <a href={`${process.env.NEXT_PUBLIC_URL}/my-view`} style={{ fontWeight: 800 }}>
+                My view
+              </a>
             </li>
             <li>
               <a href="#">Incoming referrals</a>
             </li>
             <li>
-              <a href="#">Better conversations</a>
+              <a href={process.env.NEXT_PUBLIC_URL}>Better conversations</a>
             </li>
           </ul>
         </div>
@@ -45,8 +47,8 @@ Index.getInitialProps = async ({ req: { headers }, res }) => {
 
     const referrerInfo = jsonwebtoken.decode(token);
 
-    let myReferrals = [];
-    if (referrerInfo.email) {
+    let myReferrals = { referrals: [] };
+    if (referrerInfo?.email) {
       myReferrals = await findReferrals('referrerEmail', { token });
     }
     const errors = myReferrals?.error;

--- a/pages/my-view/index.js
+++ b/pages/my-view/index.js
@@ -4,7 +4,20 @@ import { getTokenFromCookieHeader } from 'lib/utils/token';
 import jsonwebtoken from 'jsonwebtoken';
 import Head from 'next/head';
 import ReferralsTable from 'components/Feature/ReferralsTable';
+import OverviewBox from 'components/Feature/OverviewBox';
+
 const Index = ({ errors, referrerInfo, myReferrals }) => {
+  const getStatus = history => {
+    return history.sort((a, b) => {
+      return new Date(b.date) - new Date(a.date);
+    })[0].status;
+  };
+
+  const counts = {};
+
+  for (const status of myReferrals.map(x => getStatus(x.statusHistory))) {
+    counts[status] = counts[status] ? counts[status] + 1 : 1;
+  }
   return (
     <>
       <Head>
@@ -14,7 +27,7 @@ const Index = ({ errors, referrerInfo, myReferrals }) => {
       <hr className={`govuk-section-break govuk-section-break--m govuk-section-break--visible`} />
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-quarter">
-          <ul class="govuk-list">
+          <ul className="govuk-list">
             {false && (
               <li>
                 <a href="#">Team view</a>
@@ -37,6 +50,16 @@ const Index = ({ errors, referrerInfo, myReferrals }) => {
         </div>
 
         <div className="govuk-grid-column-three-quarters">
+          <h2 className="govuk-heading-m">At a glance</h2>
+          <div className="govuk-grid-row">
+            <OverviewBox number={myReferrals.length} label="Referrals made" id="referralsMade" />
+            <OverviewBox number={counts['SENT']} label="Referrals pending" id="referralsPending" />
+            <OverviewBox
+              number={counts['REJECTED']}
+              label="Referrals rejected"
+              id="referralsRejected"
+            />
+          </div>
           <h2 className="govuk-heading-m">Historic referrals</h2>
           <ReferralsTable referrals={myReferrals} />
         </div>

--- a/pages/my-view/index.js
+++ b/pages/my-view/index.js
@@ -15,17 +15,21 @@ const Index = ({ errors, referrerInfo, myReferrals }) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-quarter">
           <ul class="govuk-list">
-            <li>
-              <a href="#">Team view</a>
-            </li>
+            {false && (
+              <li>
+                <a href="#">Team view</a>
+              </li>
+            )}
             <li>
               <a href={`${process.env.NEXT_PUBLIC_URL}/my-view`} style={{ fontWeight: 800 }}>
                 My view
               </a>
             </li>
-            <li>
-              <a href="#">Incoming referrals</a>
-            </li>
+            {false && (
+              <li>
+                <a href="#">Incoming referrals</a>
+              </li>
+            )}
             <li>
               <a href={process.env.NEXT_PUBLIC_URL}>Better conversations</a>
             </li>

--- a/pages/my-view/index.js
+++ b/pages/my-view/index.js
@@ -47,11 +47,11 @@ Index.getInitialProps = async ({ req: { headers }, res }) => {
 
     let myReferrals = [];
     if (referrerInfo.email) {
-      myReferrals = await findReferrals({ referrerEmail: referrerInfo.email, token }).referrals;
+      myReferrals = await findReferrals('referrerEmail', { token });
     }
-    const errors = myReferrals.error;
+    const errors = myReferrals?.error;
     return {
-      myReferrals,
+      myReferrals: myReferrals.referrals,
       errors,
       referrerInfo
     };

--- a/pages/my-view/index.js
+++ b/pages/my-view/index.js
@@ -31,7 +31,7 @@ const Index = ({ errors, referrerInfo, myReferrals }) => {
       <Head>
         <title>Better Conversations: My view</title>
       </Head>
-      <h1 className="govuk-heading-l">{referrerInfo?.name} view</h1>
+      <h1 className="govuk-heading-l">My referrals</h1>
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-quarter">
@@ -111,7 +111,7 @@ Index.getInitialProps = async ({ req: { headers }, res }) => {
 
     let myReferrals = [];
     if (referrerInfo.email) {
-      myReferrals = await findReferrals({ referrerEmail: referrerInfo.email, token });
+      myReferrals = await findReferrals({ referrerEmail: referrerInfo.email, token }).referrals;
     }
     const errors = myReferrals.error;
     return {

--- a/pages/my-view/index.js
+++ b/pages/my-view/index.js
@@ -1,0 +1,128 @@
+import { findReferrals } from 'lib/api';
+import HttpStatusError from 'lib/api/domain/HttpStatusError';
+import { getTokenFromCookieHeader } from 'lib/utils/token';
+import jsonwebtoken from 'jsonwebtoken';
+import Head from 'next/head';
+import { convertIsoDateToString } from 'lib/utils/date';
+import css from './index.module.scss';
+const Index = ({ errors, referrerInfo, myReferrals }) => {
+  const statuses = {
+    REJECTED: {
+      label: 'Rejected',
+      class: 'rejected'
+    },
+    SENT: {
+      label: 'In Progress',
+      class: 'sent'
+    },
+    REJECTED: {
+      label: 'Approved',
+      class: 'approved'
+    }
+  };
+
+  const getStatus = history => {
+    return history.sort((a, b) => {
+      return new Date(b.date) - new Date(a.date);
+    })[0].status;
+  };
+  return (
+    <>
+      <Head>
+        <title>Better Conversations: My view</title>
+      </Head>
+      <h1 className="govuk-heading-l">{referrerInfo?.name} view</h1>
+
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-one-quarter">
+          <ul class="govuk-list">
+            <li>
+              <a href="#">Team view</a>
+            </li>
+            <li>
+              <a href="#">My view</a>
+            </li>
+            <li>
+              <a href="#">Incoming referrals</a>
+            </li>
+            <li>
+              <a href="#">Better conversations</a>
+            </li>
+          </ul>
+        </div>
+
+        <div className="govuk-grid-column-three-quarters">
+          <h2 className="govuk-heading-m">Historic referrals</h2>
+          <table className="govuk-table">
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th scope="col" className="govuk-table__header">
+                  Reference number
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Person referred
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Org referred to
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Date
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {myReferrals.map((referral, index) => {
+                return (
+                  <tr className="govuk-table__row" key={`referrals-table_row-${index}`}>
+                    <td className="govuk-table__cell">
+                      <a href="#">{referral.referenceNumber}</a>
+                    </td>
+                    <td className="govuk-table__cell">
+                      {referral.resident.firstName} {referral.resident.lastName}
+                    </td>
+                    <td className="govuk-table__cell ">{referral.service.name}</td>
+                    <td className="govuk-table__cell ">
+                      {convertIsoDateToString(new Date(referral.created))}
+                    </td>
+                    <td className={`govuk-table__cell`}>
+                      <span className={`${css[statuses[getStatus(referral.statusHistory)].class]}`}>
+                        {statuses[getStatus(referral.statusHistory)].label}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </>
+  );
+};
+
+Index.getInitialProps = async ({ req: { headers }, res }) => {
+  try {
+    const token = getTokenFromCookieHeader(headers);
+
+    const referrerInfo = jsonwebtoken.decode(token);
+
+    let myReferrals = [];
+    if (referrerInfo.email) {
+      myReferrals = await findReferrals({ referrerEmail: referrerInfo.email, token });
+    }
+    const errors = myReferrals.error;
+    return {
+      myReferrals,
+      errors,
+      referrerInfo
+    };
+  } catch (err) {
+    console.log('Failed to load initial Props:' + err);
+    res.writeHead(err instanceof HttpStatusError ? err.statusCode : 500).end();
+  }
+};
+
+export default Index;

--- a/router/use-cases/check-auth.js
+++ b/router/use-cases/check-auth.js
@@ -17,5 +17,11 @@ class CheckAuth {
       return false;
     }
   }
+
+  getEmail = token => {
+    if (!token) return '';
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    return payload ? payload.email : '';
+  };
 }
 module.exports = CheckAuth;


### PR DESCRIPTION
**What**  
Save referrer email from token into the `referredBy` column (we're saving email to `referrer.email` already, but that can be edited by the user)
Add a my-view page at /my-view which displays 
<img width="756" alt="image" src="https://user-images.githubusercontent.com/54268893/128189482-d8d22196-2716-4993-949d-760b04b478cb.png">

Change find-referrals endpoint and use case to take in the token and `findBy` (which is currently only allowed to be `referrersEmail`)
It gets the email from the token and returns all the referrals that were `referredBy` that email

**Why**  
to allow users to see their past referrals

**Anything else?**  
update dynamodb test data
