### PR TITLE
Hotfix/accept reject

### DIFF
--- a/components/Feature/StatusForm/index.js
+++ b/components/Feature/StatusForm/index.js
@@ -6,7 +6,14 @@ const StatusForm = ({ onSubmitForm, name }) => {
   return (
     <>
       <h1 className="govuk-heading-m">Referral for {name}</h1>
-      <form onSubmit={onSubmitForm}>
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          onSubmitForm(
+            e.target['referral-status'].value,
+            e.target['referral-rejection-reason'].value
+          );
+        }}>
         <div className="govuk-form-group">
           <fieldset className="govuk-fieldset">
             <div className="govuk-!-padding-top-4">

--- a/lib/use-cases/send-referral-response-email.js
+++ b/lib/use-cases/send-referral-response-email.js
@@ -19,14 +19,16 @@ export default class SendReferralResponseEmail {
       comments: recentStatus.comment
     };
 
-    let templateId = process.env.REFERRAL_REJECTED_EMAIL_TEMPLATE_ID;
+    let templateId = '';
+    process.env.REFERRAL_REJECTED_EMAIL_TEMPLATE_ID;
     if (recentStatus.status == REFERRAL_STATUSES.Accepted) {
       templateId = process.env.REFERRAL_ACCEPTED_EMAIL_TEMPLATE_ID;
-    } else {
-      if (recentStatus.comment) {
-        templateId = process.env.REFERRAL_REJECTED_WITH_COMMENTS_EMAIL_TEMPLATE_ID;
-      }
+    } else if (recentStatus.status == REFERRAL_STATUSES.Rejected) {
+      templateId = recentStatus.comment
+        ? process.env.REFERRAL_REJECTED_WITH_COMMENTS_EMAIL_TEMPLATE_ID
+        : process.env.REFERRAL_REJECTED_EMAIL_TEMPLATE_ID;
     }
+
     return await this.notifyGateway.sendEmail(templateId, emailAddress, personalisation);
   }
 }

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -30,3 +30,5 @@ export const REFERRAL_STATUSES = {
   Accepted: 'ACCEPTED',
   Rejected: 'REJECTED'
 };
+
+export const EMPTY_STATUS_ERROR = 'Empty status error';

--- a/pages/referrals/status/[id].js
+++ b/pages/referrals/status/[id].js
@@ -1,6 +1,6 @@
 import { requestByLinkId } from 'lib/api';
 import HttpStatusError from 'lib/api/domain/HttpStatusError';
-import { REFERRAL_STATUSES, STATUS_UPDATE } from 'lib/utils/constants';
+import { REFERRAL_STATUSES, STATUS_UPDATE, EMPTY_STATUS_ERROR } from 'lib/utils/constants';
 import useReferral from 'lib/api/utils/useReferral';
 import { IsoDateTime } from 'lib/domain/isodate';
 import { useState } from 'react';
@@ -25,6 +25,11 @@ const StatusHistory = ({ referral }) => {
   const onSubmitForm = async (status, comment) => {
     if (!status || status == null || status == '') {
       setErrors(true);
+      sendDataToAnalytics({
+        action: EMPTY_STATUS_ERROR,
+        category: STATUS_UPDATE,
+        label: initialReferral.service.name
+      });
       return;
     }
     setErrors(false);

--- a/pages/referrals/status/index.module.scss
+++ b/pages/referrals/status/index.module.scss
@@ -1,0 +1,8 @@
+.error-message {
+  background-color: #f4ccccff !important;
+  clear: both;
+  border-left: 2px solid;
+  border-color: #ab1f13;
+  padding: 10px 0 10px 0;
+  margin-bottom: 30px;
+}


### PR DESCRIPTION
**What**  
Set templateId for status change email to be empty. Only set the value to templateId if the response is either Accepted or Rejected.
Only send the status and comment values to onSubmitForm
Display error if status value is empty

<img width="898" alt="image" src="https://user-images.githubusercontent.com/54268893/128481800-d4558b95-dd97-45b6-983a-878d3362698a.png">


**Why**  
In some cases status history record would get logged without the status value and reject email would get sent.
