### PR TITLE
Remove useless tags

### DIFF
--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -59,11 +59,6 @@ const ResourceCard = ({
     return text;
   };
 
-  const tagsElement = resource.tags.map(item => (
-    <span key={'tags-' + item} className={`${css.tags} tag-element`}>
-      {getHighlighted(trimLength(item, 20))}
-    </span>
-  ));
   const councilTagsElement = resource.councilTags.map(item => (
     <span key={'tags-' + item} className={`${css.tags} tag-element ${css[`Council-tag`]}`}>
       {getHighlighted(trimLength(item, 20))}
@@ -92,7 +87,6 @@ const ResourceCard = ({
       {...others}
       id={`resource-container-${resource.id}`}>
       <div className={`${css.tags__container} card-header-tag`} data-testid="resource-card-tags">
-        {tagsElement}
         {councilTagsElement}
       </div>
       <div>

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.js
@@ -59,11 +59,14 @@ const ResourceCard = ({
     return text;
   };
 
-  const councilTagsElement = resource.councilTags.map(item => (
-    <span key={'tags-' + item} className={`${css.tags} tag-element ${css[`Council-tag`]}`}>
-      {getHighlighted(trimLength(item, 20))}
-    </span>
-  ));
+  // commented out because council tags were asked to be removed temporarily:
+  // const councilTagsElement = resource.councilTags.map(item => (
+  //   <span key={'tags-' + item} className={`${css.tags} tag-element ${css[`Council-tag`]}`}>
+  //     {getHighlighted(trimLength(item, 20))}
+  //   </span>
+  // ));
+
+  // This is not being used anywhere. Is this intended?
   const updateResource = () => {
     updateSelectedResources({
       name: resource.name,
@@ -86,9 +89,10 @@ const ResourceCard = ({
       className={`resource ${css.resource}`}
       {...others}
       id={`resource-container-${resource.id}`}>
-      <div className={`${css.tags__container} card-header-tag`} data-testid="resource-card-tags">
+      {/* the following is commented out because council tags were asked to be removed temporarily: */}
+      {/* <div className={`${css.tags__container} card-header-tag`} data-testid="resource-card-tags">
         {councilTagsElement}
-      </div>
+      </div> */}
       <div>
         <div className={`govuk-grid-row`}>
           <div

--- a/components/Feature/VulnerabilitiesGrid/ResourceCard/index.module.scss
+++ b/components/Feature/VulnerabilitiesGrid/ResourceCard/index.module.scss
@@ -67,25 +67,27 @@
     text-decoration: underline;
   }
 
-  .tags__container {
-    margin-bottom: 10px;
-  }
   .label {
     font-weight: bold;
   }
-  .tags {
-    background-color: $lbh-link;
-    padding: 0px 5px 1px 5px;
-    color: white;
-    margin-right: 5px;
-    font-size: 11pt;
-    font-weight: 600;
-    white-space: nowrap;
-  }
 
-  .Council-tag {
-    background-color: #00703c;
-  }
+  // commented out because council tags were asked to be removed temporarily:
+  // .tags__container {
+  //   margin-bottom: 10px;
+  // }
+  // .tags {
+  //   background-color: $lbh-link;
+  //   padding: 0px 5px 1px 5px;
+  //   color: white;
+  //   margin-right: 5px;
+  //   font-size: 11pt;
+  //   font-weight: 600;
+  //   white-space: nowrap;
+  // }
+
+  // .Council-tag {
+  //   background-color: #00703c;
+  // }
 
   .websites {
     list-style: none;

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -84,17 +84,17 @@ context('Index page', () => {
         .should('not.contain', 'This is for');
     });
 
-    it('Displays the correct tags', () => {
-      cy.get('[data-testid=category-card]')
-        .eq(0)
-        .click();
+    // it('Displays the correct tags', () => {
+    //   cy.get('[data-testid=category-card]')
+    //     .eq(0)
+    //     .click();
 
-      cy.get('[data-testid=resource-card-tags]')
-        .eq(0)
-        .should('contain', 'Magic')
-        .children()
-        .should('have.length', 1);
-    });
+    //   cy.get('[data-testid=resource-card-tags]')
+    //     .eq(0)
+    //     .should('contain', 'Magic')
+    //     .children()
+    //     .should('have.length', 1);
+    // });
 
     it('Displays the correct resource information for council resources', () => {
       cy.get('[data-testid=category-card]')
@@ -247,11 +247,14 @@ context('Index page', () => {
       cy.get('[data-testid="keyword-search"]').type('abc');
       cy.get('[data-testid="keyword-search-button"]').click();
 
-      cy.get('[data-testid="search-results-container"]')
-        .find('[data-testid="resource-card-tags"]')
-        .should('have.length', 1);
+      cy.get('[data-testid=resource-ABC123]').contains('ABC mental health Test');
 
-      cy.get('[data-testid="resource-card-tags"]').should('contain', 'Magic');
+      // commented out because council tags were asked to be removed temporarily:
+      // cy.get('[data-testid="search-results-container"]')
+      //   .find('[data-testid="resource-card-tags"]')
+      //   .should('have.length', 1);
+
+      // cy.get('[data-testid="resource-card-tags"]').should('contain', 'Magic');
     });
 
     it('returns services ordered by full match then individual word match', () => {

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -91,17 +91,9 @@ context('Index page', () => {
 
       cy.get('[data-testid=resource-card-tags]')
         .eq(0)
-        .should('contain', 'First category')
-        .and('contain', 'Magic')
+        .should('contain', 'Magic')
         .children()
-        .should('have.length', 2);
-
-      cy.get('[data-testid=resource-card-tags]')
-        .eq(2)
-        .should('contain', 'First category')
-        .and('contain', 'Second category')
-        .children()
-        .should('have.length', 2);
+        .should('have.length', 1);
     });
 
     it('Displays the correct resource information for council resources', () => {
@@ -260,7 +252,6 @@ context('Index page', () => {
         .should('have.length', 1);
 
       cy.get('[data-testid="resource-card-tags"]').should('contain', 'Magic');
-      cy.get('[data-testid="resource-card-tags"]').should('contain', 'First category');
     });
 
     it('returns services ordered by full match then individual word match', () => {


### PR DESCRIPTION
# What:
 - Removed the blue coloured tags from resource cards _(services from search results)_.
 - Commented out green coloured council tags _(from the same place)_.

# Why  
- The services listed within this application come from "Find Support Services" database. For some unclear reason when the data is being entered into FSS, it doesn't take advantage of one-to-many relationship between Organisation and Service tables.
 As a result, every organisation within FSS has only 1 service, which is actually multiple services. This means that the description & **tags** of a single service we pull down actually contains information about multiple services that an organisation offers. It's a problem, because many organisations offer the same services, so when looking into search results, pretty much every service has almost every tag in existence, making listing tags close to pointless.
- Since tags are not being relied on when picking or searching for a service, it's also best to remove them to de-clutter the user interface.

# Screenshots:
 Before            |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/43747286/129208139-106e0514-3a02-4ee2-9750-0596595cf329.png) | ![image](https://user-images.githubusercontent.com/43747286/129208192-f8bc4394-b0c5-44b3-9c09-9867b5e7861c.png)

# Notes:
- Green council tags were commented out because for the time being it's believed that it's best to remove all tags all together. However, there's a small chance that upcoming user research session will show that council tags might be needed after all, so we're keeping the code in case we need to bring it back.
- Jira ticket: [93](https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=66&projectKey=BC2&modal=detail&selectedIssue=BC2-93).
