### PR TITLE
Accept reject status bar styling

### DIFF
--- a/styles/referralStatus.module.scss
+++ b/styles/referralStatus.module.scss
@@ -1,14 +1,21 @@
+@import '../pages/stylesheets/vars.scss';
+
 .rejected {
   background-color: #d4351c;
-  color: white;
 }
 .sent {
   background-color: #1d70b8;
-  color: white;
 }
 .accepted {
-  border: solid 2px lightgray;
+  background-color: $hackney-green;
 }
+
+.sent,
+.rejected,
+.accepted {
+  color: white;
+}
+
 .sent,
 .rejected,
 .accepted,

--- a/styles/referralStatus.module.scss
+++ b/styles/referralStatus.module.scss
@@ -21,4 +21,6 @@
 .accepted,
 .empty {
   padding: 4px 15px 4px 15px;
+  text-align: center;
+  vertical-align: middle;
 }


### PR DESCRIPTION
# What:  
 - Changed "Accepted" My View page referral status tag to have green background colour.
 - Aligned text to be centered within referral status tag.  

# Why:
 - I believe, this change was requested by user feedback. Or at least someone's feedback. Apart from that I don't believe there's anything extra in play apart from visual aesthetics.

# Screenshots:
 Before            |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/43747286/129551642-f0b91a94-eaf0-4416-b8f0-4c0af1111dcf.png) | ![image](https://user-images.githubusercontent.com/43747286/129551476-e53076ec-bb83-48c1-8bab-ae4143370696.png)

# Notes:
 - Having green and red status bars was not considered an accessibility issue due to the text contained within status bar.
 - Jira ticket: [106](https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=66&projectKey=BC2&modal=detail&selectedIssue=BC2-106).
