### PR TITLE
Removed 'Leave site' warning & function.

### DIFF
--- a/pages/support-a-resident/index.js
+++ b/pages/support-a-resident/index.js
@@ -68,7 +68,6 @@ const Index = ({ categorisedResources, initialReferral, token, errors, refererIn
     <>
       <Head>
         <title>Better Conversations</title>
-        {process.env.NEXT_PUBLIC_ENV != 'test' && <script src="/js/beforeUnload.js"></script>}
       </Head>
       <div className="govuk-!-margin-top-9">
         {errors.map((err, index) => (

--- a/public/js/beforeUnload.js
+++ b/public/js/beforeUnload.js
@@ -1,3 +1,0 @@
-window.onbeforeunload = function() {
-  return "Are you sure? The resident's details will not be saved if you leave or refresh this page."
-};


### PR DESCRIPTION
# What:  
 - Removed 'Leave site' warning that warns users about potentially losing data they have entered into the form.
 - Remove function that enables this warning.

# Why:
 - Users have found this warning to be annoying. Presumably it has to do with the way they work: having a lot of application tabs open. When some get stale you just want to close them & not be bothered with a warning on every tab.

# Screenshots:

| Removed warning |
| -------- |
| ![image](https://user-images.githubusercontent.com/43747286/129713793-788aa42d-e36c-4c5e-b608-b5343c934379.png) |


# Notes:
 - Jira ticket: [103](https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=66&projectKey=BC2&modal=detail&selectedIssue=BC2-103).