### PR TITLE
Make reject referral required and styled

### DIFF
--- a/components/Feature/StatusForm/index.js
+++ b/components/Feature/StatusForm/index.js
@@ -107,7 +107,7 @@ const StatusForm = ({ onSubmitForm, name }) => {
                       spellcheck="false"
                       data-testid="status-form-rejected-comment-input"
                       onChange={onChangeRejectReason}
-                      required
+                      required={reject}
                       onInvalid={() =>
                         setValidationError({ ...validationError, rejectReason: true })
                       }

--- a/components/Feature/StatusForm/index.js
+++ b/components/Feature/StatusForm/index.js
@@ -1,6 +1,5 @@
 import { REFERRAL_STATUSES } from 'lib/utils/constants';
 import { useState } from 'react';
-import css from './index.module.css';
 
 const StatusForm = ({ onSubmitForm, name }) => {
   const [reject, setReject] = useState(false);
@@ -98,10 +97,9 @@ const StatusForm = ({ onSubmitForm, name }) => {
                       </span>
                     </span>
                     <textarea
-                      className={`govuk-textarea ${
+                      className={`govuk-textarea govuk-!-margin-bottom-0 ${
                         validationError.rejectReason ? 'govuk-input--error' : ''
                       }`}
-                      id={`${css['referral-rejection-reason']}`}
                       name="referral-rejection-reason"
                       aria-labelledby="rejection-reason"
                       spellcheck="false"

--- a/components/Feature/StatusForm/index.js
+++ b/components/Feature/StatusForm/index.js
@@ -84,7 +84,10 @@ const StatusForm = ({ onSubmitForm, name }) => {
                     validationError.rejectReason ? 'govuk-form-group--error' : ''
                   }`}>
                   <div className="govuk-!-padding-bottom-2">
-                    <label className="govuk-label" for="referral-rejection-reason">
+                    <label
+                      id="rejection-reason"
+                      className="govuk-label"
+                      for="referral-rejection-reason">
                       Reason for not accepting this referral (optional)
                     </label>
                     <span id={`reject-comment-error`} className="govuk-error-message">
@@ -100,6 +103,7 @@ const StatusForm = ({ onSubmitForm, name }) => {
                       }`}
                       id={`${css['referral-rejection-reason']}`}
                       name="referral-rejection-reason"
+                      aria-labelledby="rejection-reason"
                       spellcheck="false"
                       data-testid="status-form-rejected-comment-input"
                       onChange={onChangeRejectReason}

--- a/components/Feature/StatusForm/index.js
+++ b/components/Feature/StatusForm/index.js
@@ -6,6 +6,14 @@ const StatusForm = ({ onSubmitForm, name }) => {
   const [reject, setReject] = useState(false);
   const [status, setStatus] = useState();
   const [comment, setComment] = useState();
+  const [validationError, setValidationError] = useState({ rejectReason: false });
+
+  const onChangeRejectReason = event => {
+    const fieldValue = event.target.value;
+    const isValueEmpty = !Boolean(fieldValue);
+    setComment(fieldValue);
+    setValidationError({ ...validationError, rejectReason: isValueEmpty });
+  };
 
   return (
     <>
@@ -71,25 +79,34 @@ const StatusForm = ({ onSubmitForm, name }) => {
                 }`}
                 id="conditional-contact"
                 data-testid="status-form-rejected-comment">
-                <div className={`govuk-form-group ${false ? 'govuk-form-group--error' : ''}`}>
+                <div
+                  className={`govuk-form-group ${
+                    validationError.rejectReason ? 'govuk-form-group--error' : ''
+                  }`}>
                   <div className="govuk-!-padding-bottom-2">
                     <label className="govuk-label" for="referral-rejection-reason">
                       Reason for not accepting this referral (optional)
                     </label>
                     <span id={`reject-comment-error`} className="govuk-error-message">
-                      <span hidden={!false} data-testid="reject-comment-error">
+                      <span
+                        hidden={!validationError.rejectReason}
+                        data-testid="reject-comment-error">
                         Please provide a reason for not accepting this referral.
                       </span>
                     </span>
                     <textarea
-                      className={`govuk-textarea ${false ? 'govuk-input--error' : ''}`}
+                      className={`govuk-textarea ${
+                        validationError.rejectReason ? 'govuk-input--error' : ''
+                      }`}
                       id={`${css['referral-rejection-reason']}`}
                       name="referral-rejection-reason"
                       spellcheck="false"
                       data-testid="status-form-rejected-comment-input"
-                      onChange={e => {
-                        setComment(e.target.value);
-                      }}
+                      onChange={onChangeRejectReason}
+                      required
+                      onInvalid={() =>
+                        setValidationError({ ...validationError, rejectReason: true })
+                      }
                     />
                   </div>
                 </div>

--- a/components/Feature/StatusForm/index.js
+++ b/components/Feature/StatusForm/index.js
@@ -5,13 +5,13 @@ const StatusForm = ({ onSubmitForm, name }) => {
   const [reject, setReject] = useState(false);
   const [status, setStatus] = useState();
   const [comment, setComment] = useState();
-  const [validationError, setValidationError] = useState({ rejectReason: false });
+  const [validationError, setValidationError] = useState({ rejectReasonHasError: false });
 
   const onChangeRejectReason = event => {
     const fieldValue = event.target.value;
     const isValueEmpty = !Boolean(fieldValue);
     setComment(fieldValue);
-    setValidationError({ ...validationError, rejectReason: isValueEmpty });
+    setValidationError({ ...validationError, rejectReasonHasError: isValueEmpty });
   };
 
   return (
@@ -80,7 +80,7 @@ const StatusForm = ({ onSubmitForm, name }) => {
                 data-testid="status-form-rejected-comment">
                 <div
                   className={`govuk-form-group ${
-                    validationError.rejectReason ? 'govuk-form-group--error' : ''
+                    validationError.rejectReasonHasError ? 'govuk-form-group--error' : ''
                   }`}>
                   <div className="govuk-!-padding-bottom-2">
                     <label
@@ -91,14 +91,14 @@ const StatusForm = ({ onSubmitForm, name }) => {
                     </label>
                     <span id={`reject-comment-error`} className="govuk-error-message">
                       <span
-                        hidden={!validationError.rejectReason}
+                        hidden={!validationError.rejectReasonHasError}
                         data-testid="reject-comment-error">
                         Please provide a reason for not accepting this referral.
                       </span>
                     </span>
                     <textarea
                       className={`govuk-textarea govuk-!-margin-bottom-0 ${
-                        validationError.rejectReason ? 'govuk-input--error' : ''
+                        validationError.rejectReasonHasError ? 'govuk-input--error' : ''
                       }`}
                       name="referral-rejection-reason"
                       aria-labelledby="rejection-reason"
@@ -107,7 +107,7 @@ const StatusForm = ({ onSubmitForm, name }) => {
                       onChange={onChangeRejectReason}
                       required={reject}
                       onInvalid={() =>
-                        setValidationError({ ...validationError, rejectReason: true })
+                        setValidationError({ ...validationError, rejectReasonHasError: true })
                       }
                     />
                   </div>

--- a/components/Feature/StatusForm/index.js
+++ b/components/Feature/StatusForm/index.js
@@ -1,5 +1,6 @@
 import { REFERRAL_STATUSES } from 'lib/utils/constants';
 import { useState } from 'react';
+import css from './index.module.css';
 
 const StatusForm = ({ onSubmitForm, name }) => {
   const [reject, setReject] = useState(false);
@@ -70,20 +71,27 @@ const StatusForm = ({ onSubmitForm, name }) => {
                 }`}
                 id="conditional-contact"
                 data-testid="status-form-rejected-comment">
-                <div className="govuk-form-group">
-                  <label className="govuk-label" for="referral-rejection-reason">
-                    Reason for not accepting this referral (optional)
-                  </label>
-                  <textarea
-                    className="govuk-textarea"
-                    id="referral-rejection-reason"
-                    name="referral-rejection-reason"
-                    spellcheck="false"
-                    data-testid="status-form-rejected-comment-input"
-                    onChange={e => {
-                      setComment(e.target.value);
-                    }}
-                  />
+                <div className={`govuk-form-group ${false ? 'govuk-form-group--error' : ''}`}>
+                  <div className="govuk-!-padding-bottom-2">
+                    <label className="govuk-label" for="referral-rejection-reason">
+                      Reason for not accepting this referral (optional)
+                    </label>
+                    <span id={`reject-comment-error`} className="govuk-error-message">
+                      <span hidden={!false} data-testid="reject-comment-error">
+                        Please provide a reason for not accepting this referral.
+                      </span>
+                    </span>
+                    <textarea
+                      className={`govuk-textarea ${false ? 'govuk-input--error' : ''}`}
+                      id={`${css['referral-rejection-reason']}`}
+                      name="referral-rejection-reason"
+                      spellcheck="false"
+                      data-testid="status-form-rejected-comment-input"
+                      onChange={e => {
+                        setComment(e.target.value);
+                      }}
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/Feature/StatusForm/index.module.css
+++ b/components/Feature/StatusForm/index.module.css
@@ -1,0 +1,3 @@
+#referral-rejection-reason {
+  margin-bottom: 0;
+}

--- a/components/Feature/StatusForm/index.module.css
+++ b/components/Feature/StatusForm/index.module.css
@@ -1,3 +1,0 @@
-#referral-rejection-reason {
-  margin-bottom: 0;
-}

--- a/cypress/integration/features/changeStatus.spec.js
+++ b/cypress/integration/features/changeStatus.spec.js
@@ -38,6 +38,18 @@ context('status page', () => {
   });
 
   describe('Reject referral', () => {
+    it('should not allow to submit the form without mandatory fields selected', () => {
+      cy.visit('/referrals/status/1');
+      // Try submitting the form without giving an Accept/Reject answer
+      cy.get('[data-testid=submit-status-form]').click();
+      cy.wait(50); // wait to make sure submit has attempted to submit
+      cy.url().should('include', '/referrals/status/1');
+      // Try submitting a rejection without giving a rejection reason
+      cy.get('[data-testid=status-form-rejected-input]').click();
+      cy.get('[data-testid=submit-status-form]').click();
+      cy.url().should('include', '/referrals/status/1');
+    });
+
     it('with comment', () => {
       cy.visit('/referrals/status/1');
       cy.injectAxe();

--- a/cypress/integration/features/changeStatus.spec.js
+++ b/cypress/integration/features/changeStatus.spec.js
@@ -40,14 +40,16 @@ context('status page', () => {
   describe('Reject referral', () => {
     it('should not allow to submit the form without mandatory fields selected', () => {
       cy.visit('/referrals/status/1');
+
       // Try submitting the form without giving an Accept/Reject answer
       cy.get('[data-testid=submit-status-form]').click();
-      cy.wait(50); // wait to make sure submit has attempted to submit
-      cy.url().should('include', '/referrals/status/1');
+      cy.get('[data-testid=status-confirmation-panel]').should('not.exist');
+
       // Try submitting a rejection without giving a rejection reason
       cy.get('[data-testid=status-form-rejected-input]').click();
       cy.get('[data-testid=submit-status-form]').click();
-      cy.url().should('include', '/referrals/status/1');
+      cy.get('[data-testid=reject-comment-error]').should('not.be.hidden');
+      cy.get('[data-testid=status-confirmation-panel]').should('not.exist');
     });
 
     it('with comment', () => {

--- a/cypress/integration/pages/status.spec.js
+++ b/cypress/integration/pages/status.spec.js
@@ -1,6 +1,27 @@
 /// <reference types="cypress" />
 context('status page', () => {
   describe('Sent status', () => {
+    it('hides & shows reject reason error styles approapriately', () => {
+      cy.visit('/referrals/status/1');
+      cy.injectAxe();
+      // Error should not be visible
+      cy.get('[data-testid=status-form-rejected-input]').click();
+      cy.get('[data-testid=reject-comment-error]').should('be.hidden');
+      // Error should become visible
+      cy.get('[data-testid=submit-status-form]').click();
+      cy.get('[data-testid=reject-comment-error]').should('not.be.hidden');
+      // Accessibility
+      cy.runCheckA11y();
+      // When typing into the input, error should disappear
+      cy.get('[data-testid=status-form-rejected-comment-input]').type(
+        'Heart of the Cards, guide me! I draw!'
+      );
+      cy.get('[data-testid=reject-comment-error]').should('be.hidden');
+      // When deleting everything within input, error should reappear
+      cy.get('[data-testid=status-form-rejected-comment-input]').clear();
+      cy.get('[data-testid=reject-comment-error]').should('not.be.hidden');
+    });
+
     it('shows status form', () => {
       cy.visit('/referrals/status/1');
       cy.injectAxe();


### PR DESCRIPTION
# What:
 - Made "reject reason" field mandatory upon selecting that referral was rejected _(Accept/Reject referral status page)_.

# Why: 
 - Rejecting a referral without providing a reason does not give enough information of make informed decisions on whether to refer to organisation or how to refer to it in the future. For instance, if a company rejects a resident's referral, how should we know if that was because they: 
      - don't have the capacity to book them over the coming week, or 
      - need more information
      - no longer provide the service that is being referred to?

# Screenshots:
| Reject reason field error upon clicking Submit without filling it in |
| --- |
| ![image](https://user-images.githubusercontent.com/43747286/129892049-47f86471-21da-4193-b05c-35aeebcd7d04.png) |


# Notes:
Jira ticket: [101](https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=66&projectKey=BC2&modal=detail&selectedIssue=BC2-101).
