### PR TITLE
Highlight categories

### DIFF
--- a/components/Feature/ResourceCard/index.js
+++ b/components/Feature/ResourceCard/index.js
@@ -104,7 +104,6 @@ const ResourceCard = ({
                 getHighlighted(resource.name)
               )}
             </h3>
-            <h1> {resource.weight}</h1>
             {resource.demographic?.trim().length > 0 && (
               <span>This is for {resource.demographic}</span>
             )}

--- a/components/Feature/ResourceCard/index.js
+++ b/components/Feature/ResourceCard/index.js
@@ -104,6 +104,7 @@ const ResourceCard = ({
                 getHighlighted(resource.name)
               )}
             </h3>
+            <h1> {resource.weight}</h1>
             {resource.demographic?.trim().length > 0 && (
               <span>This is for {resource.demographic}</span>
             )}

--- a/components/Feature/Services/Categories/index.js
+++ b/components/Feature/Services/Categories/index.js
@@ -15,7 +15,7 @@ const Categories = ({ categorisedResources, selectedCategories, setSelectedCateg
 
   const categoryChanged = e => {
     let selectedCategoryIds = selectedCategories;
-    const changedCategoryId = parseInt(e.target.value);
+    const changedCategoryId = e.target.value;
     selectedCategoryIds = selectedCategoryIds.filter(item => item !== changedCategoryId);
     if (e.target.checked && changedCategoryId) {
       selectedCategoryIds.push(changedCategoryId);
@@ -35,7 +35,7 @@ const Categories = ({ categorisedResources, selectedCategories, setSelectedCateg
               type="checkbox"
               data-testid="category-checkbox"
               onChange={e => categoryChanged(e)}
-              value={group.id}
+              value={group.name}
             />
             <label
               class="govuk-label govuk-checkboxes__label"

--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -6,7 +6,7 @@ import styles from './index.module.scss';
 import { sendDataToAnalytics, getUserGroup } from 'lib/utils/analytics';
 import {
   filterByCategories,
-  getSearchResults,
+  getSearchWithWeights,
   getWordsToHighlight,
   weightByCategories
 } from 'lib/utils/search';
@@ -105,7 +105,15 @@ const Services = ({
 
     const filteredByCategory = filterByCategories(selectedCategories, categorisedResources);
 
-    let searchResults = getSearchResults(searchTerm, filteredByCategory);
+    let searchResults;
+    if (!searchTerm) {
+      searchResults = getSearchWithWeights(selectedCategories.join(' '), filteredByCategory);
+    } else {
+      searchResults = getSearchWithWeights(searchTerm, filteredByCategory).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
+    }
 
     if (selectedCategories.length > 0) {
       searchResults = weightByCategories(selectedCategories, searchResults);

--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -121,7 +121,11 @@ const Services = ({
       label: searchTerm,
       value: newFilteredResources.resources.length
     });
-    setWordsToHighlight(getWordsToHighlight(searchTerm));
+
+    const toHighlight = searchTerm
+      ? getWordsToHighlight(searchTerm)
+      : selectedCategories.map(x => getWordsToHighlight(x)).flat();
+    setWordsToHighlight(toHighlight);
     window.location.href = '#search-results-divider';
   };
 

--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -75,6 +75,7 @@ const Services = ({
           .filter(x => x?.trim())
           .map(x => x.trim())
           .join('. ');
+        res[index].weight = Math.floor((res[index].weight + resource.weight) / 2);
       } else {
         res.push(resource);
       }

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -4,7 +4,7 @@ import { removeCommonWords, getSearchableFields } from 'lib/utils/searchHelper';
 const filterByCategories = (selectedCategories, items) => {
   if (!selectedCategories || !selectedCategories.length) return items;
 
-  return items.filter(category => selectedCategories.includes(category.id));
+  return items.filter(category => selectedCategories.includes(category.name));
 };
 
 const getExcludedWords = searchedWords => {
@@ -69,14 +69,14 @@ const getCategoryWeight = (selectedCategories, categorisedResources, resource) =
     .filter(category => {
       return category.resources.some(r => r.id == resource.id);
     })
-    .map(x => x.id);
+    .map(x => x.name);
 
-  const selectedCategoriesResourceIsIn = selectedCategories.filter(id =>
-    categoriesResourceIsIn.includes(id)
+  const selectedCategoriesResourceIsIn = selectedCategories.filter(name =>
+    categoriesResourceIsIn.includes(name)
   );
 
   const unselectedCategoriesResourceIsIn = categoriesResourceIsIn.filter(
-    id => !selectedCategories.includes(id)
+    name => !selectedCategories.includes(name)
   );
 
   let percentageMatch = (selectedCategoriesResourceIsIn.length / selectedCategories.length) * 100;

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -22,18 +22,18 @@ const getExcludedWords = searchedWords => {
     .flat();
 };
 
-const getSearchResults = (searchTerm, items) => {
+const getSearchWithWeights = (searchTerm, items) => {
   let normalisedSearchTerm = normalise(searchTerm.trim());
   let words = removeCommonWords(normalisedSearchTerm.split(' '));
   let excludedWords = getExcludedWords(words);
 
   return JSON.parse(JSON.stringify(items)).map(item => {
-    item.resources = item.resources
-      .map(resource => {
-        resource.weight = getWeight(normalisedSearchTerm, resource, words, excludedWords);
-        return resource;
-      })
-      .filter(x => x.weight > 0);
+    item.resources = item.resources.map(resource => {
+      let currentWeight = resource.weight || 0;
+      resource.weight =
+        currentWeight + getWeight(normalisedSearchTerm, resource, words, excludedWords);
+      return resource;
+    });
 
     return item;
   });
@@ -57,7 +57,8 @@ const getWeight = (searchTerm, resource, words, excludedWords) => {
 const weightByCategories = (selectedCategories, items) => {
   return JSON.parse(JSON.stringify(items)).map(item => {
     item.resources = item.resources.map(resource => {
-      resource.weight = getCategoryWeight(selectedCategories, items, resource);
+      let currentWeight = resource.weight || 0;
+      resource.weight = currentWeight + getCategoryWeight(selectedCategories, items, resource);
       return resource;
     });
     return item;
@@ -175,4 +176,4 @@ const getWordsToHighlight = searchTerm => {
     .filter(x => x != '');
 };
 
-export { getSearchResults, getWordsToHighlight, filterByCategories, weightByCategories };
+export { getSearchWithWeights, getWordsToHighlight, filterByCategories, weightByCategories };

--- a/lib/utils/search.test.js
+++ b/lib/utils/search.test.js
@@ -1,5 +1,5 @@
 import {
-  getSearchResults,
+  getSearchWithWeights,
   getWordsToHighlight,
   filterByCategories,
   weightByCategories
@@ -93,9 +93,12 @@ describe('search', () => {
   ];
 
   describe('full term search', () => {
-    it('returns items where the search text is found in the description', () => {
+    it('set items weight to over 0 where the search text is found in the description', () => {
       const searchText = 'Big Orc';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources[0].description).toEqual(searchText);
@@ -103,7 +106,10 @@ describe('search', () => {
 
     it('returns items where the search text is found in name', () => {
       const searchText = 'giant ostrich';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources[0].name).toEqual(searchText);
@@ -111,7 +117,10 @@ describe('search', () => {
 
     it('returns items where the search text is found in service description', () => {
       const searchText = 'zebra hybrid';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources[0].serviceDescription).toContain(searchText);
@@ -119,13 +128,19 @@ describe('search', () => {
 
     it('applies a case insensitive search', () => {
       const searchTextLower = 'big orc';
-      const filteredServicesLower = getSearchResults(searchTextLower, allServices);
+      const filteredServicesLower = getSearchWithWeights(searchTextLower, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServicesLower[0].resources.length).toBe(1);
       expect(filteredServicesLower[0].resources[0].id).toEqual(1);
 
       const searchTextUpper = 'BIG ORC';
-      const filteredServicesUpper = getSearchResults(searchTextUpper, allServices);
+      const filteredServicesUpper = getSearchWithWeights(searchTextUpper, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServicesUpper[0].resources.length).toBe(1);
       expect(filteredServicesUpper[0].resources[0].id).toEqual(1);
@@ -135,13 +150,19 @@ describe('search', () => {
   describe('individual word search', () => {
     it('returns items where a word in the search text is found in the description', () => {
       const searchText = 'Find service';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(2);
     });
     it('returns items where a word in the search text is found in name', () => {
       const searchText = 'ostric monkey';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources[0].id).toEqual(1);
@@ -149,7 +170,10 @@ describe('search', () => {
 
     it('returns items where a word in the search text is found in service description', () => {
       const searchText = 'zebra monkey';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources[0].id).toEqual(1);
@@ -157,27 +181,39 @@ describe('search', () => {
 
     it('applies a case insensitive search', () => {
       const searchTextLower = 'find';
-      const filteredServicesLower = getSearchResults(searchTextLower, allServices);
+      const filteredServicesLower = getSearchWithWeights(searchTextLower, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServicesLower[0].resources.length).toBe(1);
       expect(filteredServicesLower[0].resources[0].id).toEqual(3);
 
       const searchTextUpper = 'FIND';
-      const filteredServicesUpper = getSearchResults(searchTextUpper, allServices);
+      const filteredServicesUpper = getSearchWithWeights(searchTextUpper, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServicesUpper[0].resources.length).toBe(1);
       expect(filteredServicesUpper[0].resources[0].id).toEqual(3);
     });
     it('ignores 1 character letters, numbers or symbols', () => {
       const searchText = 'a big orc';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources[0].id).toEqual(1);
     });
     it('ignores common conjunctions', () => {
       const searchText = 'i is a big orc';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources[0].id).toEqual(1);
@@ -187,13 +223,19 @@ describe('search', () => {
   describe('empty search', () => {
     it('returns everything if search term is an empty string', () => {
       const searchText = '';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(4);
     });
     it('returns everything if search term consists of whitespace only', () => {
       const searchText = '   ';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(4);
     });
@@ -242,7 +284,10 @@ describe('search', () => {
     describe('ordering of search results', () => {
       it('returns items containing the full phrase before items containing an individual word', () => {
         const searchText = 'i is a service';
-        const filteredServices = getSearchResults(searchText, allServices);
+        const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+          item.resources = item.resources.filter(x => x.weight > 0);
+          return item;
+        });
 
         var fullMatchItem = filteredServices[0].resources.filter(x => x.id == 2)[0];
         var wordMatchItem = filteredServices[0].resources.filter(x => x.id == 3)[0];
@@ -252,7 +297,10 @@ describe('search', () => {
       });
       it('weights a title match higher than a content match for individual words', () => {
         const searchText = 'cake';
-        const filteredServices = getSearchResults(searchText, allServices);
+        const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+          item.resources = item.resources.filter(x => x.weight > 0);
+          return item;
+        });
 
         var titleMatchItem = filteredServices[0].resources.filter(x => x.id == 4)[0];
         var contentMatchItem = filteredServices[0].resources.filter(x => x.id == 1)[0];
@@ -262,7 +310,10 @@ describe('search', () => {
       });
       it('gives a higher weight if multiple words are found compared to one word found', () => {
         const searchText = 'biscuit cheese';
-        const filteredServices = getSearchResults(searchText, allServices);
+        const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+          item.resources = item.resources.filter(x => x.weight > 0);
+          return item;
+        });
 
         var multipleMatchItem = filteredServices[0].resources.filter(x => x.id == 3)[0];
         var singleMatchItem = filteredServices[0].resources.filter(x => x.id == 4)[0];
@@ -272,7 +323,10 @@ describe('search', () => {
       });
       it('returns only items with a weight higher than zero', () => {
         const searchText = 'sdjkfhdsjkfhsdkf';
-        const filteredServices = getSearchResults(searchText, allServices);
+        const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+          item.resources = item.resources.filter(x => x.weight > 0);
+          return item;
+        });
 
         expect(filteredServices[0].resources.length).toBe(0);
       });
@@ -282,7 +336,10 @@ describe('search', () => {
   describe('synonym search', () => {
     it('returns a record with weight of 30 if it was matched on a synonym', () => {
       const searchText = 'testsynonym';
-      const filteredServices = getSearchResults(searchText, allServices);
+      const filteredServices = getSearchWithWeights(searchText, allServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources[0].id).toEqual(1);
@@ -322,7 +379,10 @@ describe('search', () => {
   describe('search exclusions', () => {
     it('excludes results containing terms configured to be excluded', () => {
       const searchText = '';
-      const filteredServices = getSearchResults(searchText, excludeTestsServices);
+      const filteredServices = getSearchWithWeights(searchText, excludeTestsServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
       expect(filteredServices[0].resources.length).toBe(3);
       expect(filteredServices[0].resources.filter(x => x.name == 'giant ostrich').length).toEqual(
         0
@@ -331,7 +391,10 @@ describe('search', () => {
 
     it('ignores excluded words if the user searches for one of them', () => {
       const searchText = 'mrzombie';
-      const filteredServices = getSearchResults(searchText, excludeTestsServices);
+      const filteredServices = getSearchWithWeights(searchText, excludeTestsServices).map(item => {
+        item.resources = item.resources.filter(x => x.weight > 0);
+        return item;
+      });
 
       expect(filteredServices[0].resources.length).toBe(1);
       expect(filteredServices[0].resources.filter(x => x.name == 'giant ostrich').length).toEqual(

--- a/lib/utils/search.test.js
+++ b/lib/utils/search.test.js
@@ -206,17 +206,17 @@ describe('search', () => {
       expect(filteredServices[0].resources.length).toBe(4);
     });
     it('filters by selected categories', () => {
-      const filteredByCatId1 = filterByCategories([1], allServices);
-      const filteredByCatId3 = filterByCategories([3], allServices);
+      const filteredByCatName1 = filterByCategories(['Loneliness'], allServices);
+      const filteredByCatName3 = filterByCategories(['noName'], allServices);
 
-      expect(filteredByCatId1[0].id).toBe(1);
-      expect(filteredByCatId3.length).toBe(0);
+      expect(filteredByCatName1[0].id).toBe(1);
+      expect(filteredByCatName3.length).toBe(0);
     });
   });
 
   describe('ordering by weight within category', () => {
     it('weights services lower if they provide for unselected categories', () => {
-      const weightedResults = weightByCategories([1], allServices);
+      const weightedResults = weightByCategories(['Loneliness'], allServices);
       const onlyExistsInSelectedCategory = weightedResults[0].resources.filter(x => x.id === 1)[0];
       const existsInSelectedAndUnselectedCategory = weightedResults[1].resources.filter(
         x => x.id === 4
@@ -227,7 +227,7 @@ describe('search', () => {
     });
 
     it('weights services higher if they exist in multiple selected categories', () => {
-      const weightedResults = weightByCategories([1, 2], allServices);
+      const weightedResults = weightByCategories(['Loneliness', 'Cat2'], allServices);
       const existsInOneSelectedCategory = weightedResults[0].resources.filter(x => x.id === 1)[0];
       const existsInBothSelectedCategories = weightedResults[1].resources.filter(
         x => x.id === 4

--- a/lib/utils/searchHelper.js
+++ b/lib/utils/searchHelper.js
@@ -29,7 +29,8 @@ const commonWords = [
   'is',
   'of',
   'an',
-  'hackney'
+  'hackney',
+  'advice'
 ];
 
 const removeCommonWords = words => {


### PR DESCRIPTION
**What**  
Highlight categories within service description if no search term is entered.
Weight the resources with categories within the descriptions higher.

**Why**  
To make the category search more valuable and accurate and increase user confidence in the results.

**Anything else?**  
Add to the current weight when calling `weightByCategories` instead of resetting the weight
Get the average of the weights when flattening the resources instead of getting the first one
Log selectedCategories as names instead of IDs to enable searching by categories
