### PR TITLE
Feature/include specific needs

### DIFF
--- a/components/Feature/Services/SpecificNeeds/index.js
+++ b/components/Feature/Services/SpecificNeeds/index.js
@@ -1,0 +1,49 @@
+import { isJSON } from 'lib/utils/search';
+
+const SpecificNeeds = ({ selectedSpecificNeeds, setSelectedSpecificNeeds }) => {
+  const specificNeeds = isJSON(process.env.SEARCH_EXCLUSIONS)
+    ? JSON.parse(process.env.SEARCH_EXCLUSIONS)
+    : [];
+
+  const specificNeedsLabels = specificNeeds.map(exclusion => exclusion.label).flat();
+
+  const specificNeedsChanged = e => {
+    let selectedSpecificNeedsLabels = selectedSpecificNeeds;
+    const clickedSpecificNeed = e.target.value;
+    selectedSpecificNeedsLabels = selectedSpecificNeedsLabels.filter(
+      item => item !== clickedSpecificNeed
+    );
+    if (e.target.checked && clickedSpecificNeed) {
+      selectedSpecificNeedsLabels.push(clickedSpecificNeed);
+    }
+    setSelectedSpecificNeeds(selectedSpecificNeedsLabels);
+  };
+
+  return (
+    <div>
+      {specificNeedsLabels.map(label => {
+        return (
+          <div className="govuk-checkboxes__item">
+            <input
+              className="govuk-checkboxes__input"
+              id={`specific-needs-cb-${label}`}
+              name={`specific-needs-cb`}
+              type="checkbox"
+              data-testid="specific-needs-checkbox"
+              onChange={e => specificNeedsChanged(e)}
+              value={label}
+            />
+            <label
+              className="govuk-label govuk-checkboxes__label"
+              htmlFor={`specific-needs-cb-${label}`}
+              data-testid="specific-needs-label">
+              {label}
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SpecificNeeds;

--- a/components/Feature/Services/SpecificNeeds/index.module.scss
+++ b/components/Feature/Services/SpecificNeeds/index.module.scss
@@ -1,0 +1,8 @@
+.row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.column {
+  display: flex;
+}

--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -9,7 +9,8 @@ import {
   filterByCategories,
   getSearchWithWeights,
   getWordsToHighlight,
-  weightByCategories
+  weightByCategories,
+  filterOutExcludedWords
 } from 'lib/utils/search';
 import { CATEGORY_SEARCH, FEEDBACK_SEARCH, SHOW_MORE_RESULTS } from 'lib/utils/constants';
 
@@ -108,19 +109,16 @@ const Services = ({
 
     const filteredByCategory = filterByCategories(selectedCategories, categorisedResources);
 
+    const filteredOutExcludedWords =
+      searchTerm || selectedCategories.length > 0
+        ? filterOutExcludedWords(searchTerm, filteredByCategory, selectedSpecificNeeds)
+        : filteredByCategory;
+
     let searchResults;
     if (!searchTerm) {
-      searchResults = getSearchWithWeights(
-        selectedCategories.join(' '),
-        filteredByCategory,
-        selectedSpecificNeeds
-      );
+      searchResults = getSearchWithWeights(selectedCategories.join(' '), filteredOutExcludedWords);
     } else {
-      searchResults = getSearchWithWeights(
-        searchTerm,
-        filteredByCategory,
-        selectedSpecificNeeds
-      ).map(item => {
+      searchResults = getSearchWithWeights(searchTerm, filteredOutExcludedWords).map(item => {
         item.resources = item.resources.filter(x => x.weight > 0);
         return item;
       });

--- a/components/Feature/Services/index.js
+++ b/components/Feature/Services/index.js
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import ResourceCard from 'components/Feature/ResourceCard';
 import Categories from './Categories';
 import Details from 'components/Form/Details';
+import SpecificNeeds from './SpecificNeeds';
 import styles from './index.module.scss';
 import { sendDataToAnalytics, getUserGroup } from 'lib/utils/analytics';
 import {
@@ -37,6 +38,7 @@ const Services = ({
   const [resultsTitle, setResultsTitle] = useState(null);
   const [wordsToHighlight, setWordsToHighlight] = useState([]);
   const [selectedCategories, setSelectedCategories] = useState([]);
+  const [selectedSpecificNeeds, setSelectedSpecificNeeds] = useState([]);
   const [showMoreResults, setShowMoreResults] = useState(false);
 
   const detailsClicked = (e, id, serviceId, categoryName) => {
@@ -108,9 +110,17 @@ const Services = ({
 
     let searchResults;
     if (!searchTerm) {
-      searchResults = getSearchWithWeights(selectedCategories.join(' '), filteredByCategory);
+      searchResults = getSearchWithWeights(
+        selectedCategories.join(' '),
+        filteredByCategory,
+        selectedSpecificNeeds
+      );
     } else {
-      searchResults = getSearchWithWeights(searchTerm, filteredByCategory).map(item => {
+      searchResults = getSearchWithWeights(
+        searchTerm,
+        filteredByCategory,
+        selectedSpecificNeeds
+      ).map(item => {
         item.resources = item.resources.filter(x => x.weight > 0);
         return item;
       });
@@ -154,6 +164,14 @@ const Services = ({
                 categorisedResources={categorisedResources}
                 selectedCategories={selectedCategories}
                 setSelectedCategories={setSelectedCategories}
+              />
+            </div>
+            <div className="govuk-grid-row govuk-!-margin-bottom-6">
+              <h2 className={`govuk-heading-m`}>Select all that apply</h2>
+
+              <SpecificNeeds
+                selectedSpecificNeeds={selectedSpecificNeeds}
+                setSelectedSpecificNeeds={setSelectedSpecificNeeds}
               />
             </div>
             <div className="govuk-grid-row govuk-!-margin-bottom-6">

--- a/cypress/integration/features/createReferral.spec.js
+++ b/cypress/integration/features/createReferral.spec.js
@@ -78,6 +78,8 @@ describe('Referral form', () => {
   });
 
   it('Persists referral information across different referral fields', () => {
+    cy.visit('/support-a-resident');
+
     cy.get('[data-testid=category-checkbox]')
       .eq(0)
       .click();

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -21,21 +21,15 @@ context('Support a resident page', () => {
     it('shows category headers containing resources', () => {
       cy.get('[data-testid=search-results-container]').should('not.exist');
 
-      cy.get('[data-testid=category-checkbox]')
-        .eq(0)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
       cy.get('[data-testid=search-results-container]').should('contain', 'First service');
 
-      cy.get('[data-testid=category-checkbox]')
-        .eq(1)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(1).click();
 
-      cy.get('[data-testid=category-checkbox]')
-        .eq(0)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
@@ -59,59 +53,31 @@ context('Support a resident page', () => {
     });
 
     it('Displays the resources', () => {
-      cy.get('[data-testid=category-checkbox]')
-        .eq(0)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
       cy.get('[data-testid=resource-card-header]').should('have.length', 5);
 
-      cy.get('[data-testid=resource-1]')
-        .eq(0)
-        .should('contain', 'First service');
+      cy.get('[data-testid=resource-1]').eq(0).should('contain', 'First service');
 
-      cy.get('[data-testid=resource-2]')
-        .eq(0)
-        .should('contain', 'Second service');
+      cy.get('[data-testid=resource-2]').eq(0).should('contain', 'Second service');
     });
 
     it('Does not show demographics label when there are no demographics', () => {
-      cy.get('[data-testid=category-checkbox]')
-        .eq(1)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(1).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
-      cy.get('[data-testid=resource-2]')
-        .eq(0)
-        .should('contain', 'Second service');
+      cy.get('[data-testid=resource-2]').eq(0).should('contain', 'Second service');
 
-      cy.get('[data-testid=resource-1]')
-        .eq(0)
-        .should('contain', 'This is for');
+      cy.get('[data-testid=resource-1]').eq(0).should('contain', 'This is for');
 
-      cy.get('[data-testid=resource-2]')
-        .eq(0)
-        .should('not.contain', 'This is for');
+      cy.get('[data-testid=resource-2]').eq(0).should('not.contain', 'This is for');
     });
 
-    // it('Displays the correct tags', () => {
-    //   cy.get('[data-testid=category-card]')
-    //     .eq(0)
-    //     .click();
-
-    //   cy.get('[data-testid=resource-card-tags]')
-    //     .eq(0)
-    //     .should('contain', 'Magic')
-    //     .children()
-    //     .should('have.length', 1);
-    // });
-
     it('Displays the correct resource information for council resources', () => {
-      cy.get('[data-testid=category-checkbox]')
-        .eq(0)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
@@ -134,9 +100,7 @@ context('Support a resident page', () => {
     });
 
     it('Displays the correct resource information for FSS resources', () => {
-      cy.get('[data-testid=category-checkbox]')
-        .eq(0)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
@@ -159,44 +123,30 @@ context('Support a resident page', () => {
     });
 
     it('Displays only the Create Referral button if both an email and website exist in service data', () => {
-      cy.get('[data-testid=category-checkbox]')
-        .eq(0)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
-      cy.get('[data-testid=resource-abc]')
-        .eq(0)
-        .should('contain', 'Kingsman');
+      cy.get('[data-testid=resource-abc]').eq(0).should('contain', 'Kingsman');
 
       cy.get('[data-testid=resource-abc]')
         .find('[data-testid=refer-button]')
         .first()
         .should('contain', 'Create Referral');
 
-      cy.get('[data-testid=resource-abc]')
-        .find('[data-testid=refer-link]')
-        .should('not.exist');
+      cy.get('[data-testid=resource-abc]').find('[data-testid=refer-link]').should('not.exist');
 
-      cy.get('[data-testid=resource-2]')
-        .find('[data-testid=refer-text]')
-        .should('not.exist');
+      cy.get('[data-testid=resource-2]').find('[data-testid=refer-text]').should('not.exist');
     });
 
     it('Displays only the Referral Link if only a website exists in service data', () => {
-      cy.get('[data-testid=category-checkbox]')
-        .eq(0)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
-      cy.get('[data-testid=resource-2]')
-        .eq(0)
-        .should('contain', 'Second service');
+      cy.get('[data-testid=resource-2]').eq(0).should('contain', 'Second service');
 
-      cy.get('[data-testid=resource-2]')
-        .find('[data-testid=refer-text]')
-        .should('not.exist');
+      cy.get('[data-testid=resource-2]').find('[data-testid=refer-text]').should('not.exist');
 
       cy.get('[data-testid=resource-2]')
         .find('[data-testid=refer-link]')
@@ -206,19 +156,13 @@ context('Support a resident page', () => {
     });
 
     it('Clicking Create Referral opens a form that will send to the correct email address', () => {
-      cy.get('[data-testid=category-checkbox]')
-        .eq(0)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
 
       cy.get('[data-testid=keyword-search-button]').click();
 
-      cy.get('[data-testid=resource-abc]')
-        .eq(0)
-        .should('contain', 'Kingsman');
+      cy.get('[data-testid=resource-abc]').eq(0).should('contain', 'Kingsman');
 
-      cy.get('[data-testid=resource-abc]')
-        .find('[data-testid=refer-button]')
-        .click();
+      cy.get('[data-testid=resource-abc]').find('[data-testid=refer-button]').click();
 
       cy.get('[data-testid=resource-abc]')
         .find('input[name="service-referral-email"]')
@@ -271,13 +215,6 @@ context('Support a resident page', () => {
       cy.get('[data-testid="keyword-search-button"]').click();
 
       cy.get('[data-testid=resource-ABC123]').contains('ABC mental health Test');
-
-      // commented out because council tags were asked to be removed temporarily:
-      // cy.get('[data-testid="search-results-container"]')
-      //   .find('[data-testid="resource-card-tags"]')
-      //   .should('have.length', 1);
-
-      // cy.get('[data-testid="resource-card-tags"]').should('contain', 'Magic');
     });
 
     it('returns services ordered by full match then individual word match', () => {
@@ -310,9 +247,7 @@ context('Support a resident page', () => {
 
   describe('Add to summary', () => {
     it('persists checked summaries across different service views', () => {
-      cy.get('[data-testid=category-checkbox]')
-        .eq(1)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(1).click();
 
       cy.get('[data-testid="keyword-search"]').clear();
 
@@ -324,13 +259,9 @@ context('Support a resident page', () => {
 
       cy.get('#add-to-summary-checkbox-1').should('be.checked');
 
-      cy.get('[data-testid=category-checkbox]')
-        .eq(2)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(2).click();
 
-      cy.get('[data-testid=category-checkbox]')
-        .eq(1)
-        .click();
+      cy.get('[data-testid=category-checkbox]').eq(1).click();
       cy.get('#add-to-summary-checkbox-1').should('be.checked');
       cy.runCheckA11y();
     });
@@ -340,6 +271,31 @@ context('Support a resident page', () => {
     it('Redirects to my view when it is selected from the navigation', () => {
       cy.get('[data-testid=my-view-nav]').click({ force: true });
       cy.url().should('include', '/my-view');
+    });
+  });
+
+  describe('Specific Needs', () => {
+    it('shows correct specific needs checkboxes', () => {
+      cy.visit('/support-a-resident');
+
+      cy.get('[data-testid=search-results-container]').should('not.exist');
+
+      const searchTerm = 'First service';
+      cy.get('[data-testid="keyword-search"]').type(searchTerm);
+
+      cy.get('[data-testid=keyword-search-button]').click();
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'First service');
+
+      cy.get('[data-testid=search-results-container]').should('not.contain', 'mrzombie');
+
+      cy.get('[data-testid=specific-needs-checkbox]').eq(0).click();
+
+      cy.get('[data-testid=keyword-search-button]').click();
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'First service');
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'mrzombie');
     });
   });
 });

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -57,7 +57,7 @@ context('Support a resident page', () => {
 
       cy.get('[data-testid=keyword-search-button]').click();
 
-      cy.get('[data-testid=resource-card-header]').should('have.length', 5);
+      cy.get('[data-testid=resource-card-header]').should('have.length', 6);
 
       cy.get('[data-testid=resource-1]').eq(0).should('contain', 'First service');
 
@@ -181,7 +181,7 @@ context('Support a resident page', () => {
 
       cy.get('[data-testid="search-results-container"]')
         .find('[data-testid="resource-card-header"]')
-        .should('have.length', 7);
+        .should('have.length', 8);
 
       cy.get('[data-testid="show-more-button"]').should('not.exist');
 
@@ -280,12 +280,12 @@ context('Support a resident page', () => {
 
       cy.get('[data-testid=search-results-container]').should('not.exist');
 
-      const searchTerm = 'First service';
+      const searchTerm = 'Third service';
       cy.get('[data-testid="keyword-search"]').type(searchTerm);
 
       cy.get('[data-testid=keyword-search-button]').click();
 
-      cy.get('[data-testid=search-results-container]').should('contain', 'First service');
+      cy.get('[data-testid=search-results-container]').should('contain', 'Third service');
 
       cy.get('[data-testid=search-results-container]').should('not.contain', 'mrzombie');
 
@@ -293,7 +293,43 @@ context('Support a resident page', () => {
 
       cy.get('[data-testid=keyword-search-button]').click();
 
-      cy.get('[data-testid=search-results-container]').should('contain', 'First service');
+      cy.get('[data-testid=search-results-container]').should('contain', 'Third service');
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'mrzombie');
+    });
+
+    it('shows excluded service when nothing is selected', () => {
+      cy.get('[data-testid=specific-needs-checkbox]').eq(0).click();
+
+      cy.get('[data-testid="keyword-search"]').clear();
+
+      cy.get('[data-testid=keyword-search-button]').click();
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'Third service');
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'mrzombie');
+    });
+
+    it('excludes service when category is selected', () => {
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
+
+      cy.get('[data-testid=category-checkbox]').eq(1).click();
+
+      cy.get('[data-testid=keyword-search-button]').click();
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'Third service');
+
+      cy.get('[data-testid=search-results-container]').should('not.contain', 'mrzombie');
+    });
+
+    it('shows the excluded service when the specific need checkbox is checked', () => {
+      cy.get('[data-testid=specific-needs-label]').eq(0).should('contain', 'Rick Grimes');
+
+      cy.get('[data-testid=specific-needs-checkbox]').eq(0).click();
+
+      cy.get('[data-testid=keyword-search-button]').click();
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'Third service');
 
       cy.get('[data-testid=search-results-container]').should('contain', 'mrzombie');
     });

--- a/cypress/integration/pages/home.spec.js
+++ b/cypress/integration/pages/home.spec.js
@@ -333,5 +333,15 @@ context('Support a resident page', () => {
 
       cy.get('[data-testid=search-results-container]').should('contain', 'mrzombie');
     });
+
+    it('only shows the excluded service when only the specific need checkbox is checked', () => {
+      cy.get('[data-testid=category-checkbox]').eq(0).click();
+      cy.get('[data-testid=category-checkbox]').eq(1).click();
+      cy.get('[data-testid=keyword-search-button]').click();
+
+      cy.get('[data-testid=search-results-container]').should('contain', 'Third service');
+      cy.get('[data-testid=search-results-container]').should('contain', 'mrzombie');
+      cy.get('[data-testid=resource-card-header]').should('have.length', 1);
+    });
   });
 });

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -22,21 +22,21 @@ const getExcludedWords = searchedWords => {
     .flat();
 };
 
-const getExcludedLabelsToWords = selectedLabels => {
+const getSpecificNeedsWords = labels => {
   const exclusions = isJSON(process.env.SEARCH_EXCLUSIONS)
     ? JSON.parse(process.env.SEARCH_EXCLUSIONS)
     : [];
 
   return exclusions
-    .filter(exclusion => selectedLabels.includes(exclusion.label))
+    .filter(exclusion => labels.includes(exclusion.label))
     .map(exclusion => exclusion.excludeWords)
     .flat();
 };
 
-const getSearchWithWeights = (searchTerm, items, selectedExcludedLabels = []) => {
+const getSearchWithWeights = (searchTerm, items, selectedSpecificNeeds = []) => {
   let normalisedSearchTerm = normalise(searchTerm.trim());
   let words = removeCommonWords(normalisedSearchTerm.split(' '));
-  let wordsToInclude = getExcludedLabelsToWords(selectedExcludedLabels);
+  let wordsToInclude = getSpecificNeedsWords(selectedSpecificNeeds);
   let excludedWords = getExcludedWords(words.concat(wordsToInclude));
 
   return JSON.parse(JSON.stringify(items)).map(item => {

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -206,5 +206,6 @@ export {
   filterByCategories,
   weightByCategories,
   isJSON,
-  filterOutExcludedWords
+  filterOutExcludedWords,
+  getSpecificNeedsWords
 };

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -188,4 +188,10 @@ const getWordsToHighlight = searchTerm => {
     .filter(x => x != '');
 };
 
-export { getSearchWithWeights, getWordsToHighlight, filterByCategories, weightByCategories };
+export {
+  getSearchWithWeights,
+  getWordsToHighlight,
+  filterByCategories,
+  weightByCategories,
+  isJSON
+};

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -7,6 +7,23 @@ const filterByCategories = (selectedCategories, items) => {
   return items.filter(category => selectedCategories.includes(category.name));
 };
 
+const filterOutExcludedWords = (searchTerm, items, selectedSpecificNeeds = []) => {
+  let normalisedSearchTerm = normalise(searchTerm.trim());
+  let words = removeCommonWords(normalisedSearchTerm.split(' '));
+  let wordsToInclude = getSpecificNeedsWords(selectedSpecificNeeds);
+  let excludedWords = getExcludedWords(words.concat(wordsToInclude));
+
+  return JSON.parse(JSON.stringify(items)).map(item => {
+    item.resources = item.resources.filter(item => !includesExcludedWord(excludedWords, item));
+    return item;
+  });
+};
+
+const includesExcludedWord = (excludedWords, item) => {
+  const resourceIndex = getSearchableFields(item);
+  return getIndividualWordsWeight(excludedWords, resourceIndex) > 0;
+};
+
 const getExcludedWords = searchedWords => {
   const exclusions = isJSON(process.env.SEARCH_EXCLUSIONS)
     ? JSON.parse(process.env.SEARCH_EXCLUSIONS)
@@ -33,17 +50,14 @@ const getSpecificNeedsWords = labels => {
     .flat();
 };
 
-const getSearchWithWeights = (searchTerm, items, selectedSpecificNeeds = []) => {
+const getSearchWithWeights = (searchTerm, items) => {
   let normalisedSearchTerm = normalise(searchTerm.trim());
   let words = removeCommonWords(normalisedSearchTerm.split(' '));
-  let wordsToInclude = getSpecificNeedsWords(selectedSpecificNeeds);
-  let excludedWords = getExcludedWords(words.concat(wordsToInclude));
 
   return JSON.parse(JSON.stringify(items)).map(item => {
     item.resources = item.resources.map(resource => {
       let currentWeight = resource.weight || 0;
-      resource.weight =
-        currentWeight + getWeight(normalisedSearchTerm, resource, words, excludedWords);
+      resource.weight = currentWeight + getWeight(normalisedSearchTerm, resource, words);
       return resource;
     });
 
@@ -51,10 +65,8 @@ const getSearchWithWeights = (searchTerm, items, selectedSpecificNeeds = []) => 
   });
 };
 
-const getWeight = (searchTerm, resource, words, excludedWords) => {
+const getWeight = (searchTerm, resource, words) => {
   const resourceIndex = getSearchableFields(resource);
-
-  if (getIndividualWordsWeight(excludedWords, resourceIndex) > 0) return 0;
 
   let weight = resource.weight || 0;
 
@@ -193,5 +205,6 @@ export {
   getWordsToHighlight,
   filterByCategories,
   weightByCategories,
-  isJSON
+  isJSON,
+  filterOutExcludedWords
 };

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -91,9 +91,7 @@ const weightByCategories = (selectedCategories, items) => {
 
 const getCategoryWeight = (selectedCategories, categorisedResources, resource) => {
   const categoriesResourceIsIn = categorisedResources
-    .filter(category => {
-      return category.resources.some(r => r.id == resource.id);
-    })
+    .filter(category => category.resources.some(r => r.id == resource.id))
     .map(x => x.name);
 
   const selectedCategoriesResourceIsIn = selectedCategories.filter(name =>
@@ -200,6 +198,67 @@ const getWordsToHighlight = searchTerm => {
     .filter(x => x != '');
 };
 
+const flattenSearchResults = searchResults => {
+  if (!searchResults) return { resources: [] };
+  const resources = searchResults.map(category => category.resources).flat();
+  let res = [];
+  resources.forEach(resource => {
+    let index = res.findIndex(x => x.id === resource.id);
+    if (index > -1) {
+      res[index].description = [res[index].description, resource.description]
+        .filter(x => x?.trim())
+        .map(x => x.trim())
+        .join('. ');
+      res[index].weight = Math.floor((res[index].weight + resource.weight) / 2);
+    } else {
+      res.push(resource);
+    }
+  });
+  return {
+    name: `${res.length} ${res.length == 1 ? 'result' : 'results'}`,
+    resources: res
+  };
+};
+
+const getSearchResult = ({
+  categorisedResources = [],
+  searchTerm = '',
+  selectedCategories = [],
+  selectedSpecificNeeds = []
+}) => {
+  let searchResults = { resources: [] };
+
+  searchResults = filterByCategories(selectedCategories, categorisedResources);
+
+  if (searchTerm || selectedCategories.length > 0) {
+    searchResults = filterOutExcludedWords(searchTerm, searchResults, selectedSpecificNeeds);
+  }
+
+  if (searchTerm) {
+    searchResults = getSearchWithWeights(searchTerm, searchResults);
+  } else if (selectedCategories.length > 0) {
+    searchResults = getSearchWithWeights(selectedCategories.join(' '), searchResults);
+  }
+
+  if (selectedSpecificNeeds.length > 0) {
+    const specificNeedsWords = getSpecificNeedsWords(selectedSpecificNeeds);
+    searchResults = getSearchWithWeights(specificNeedsWords.join(' '), searchResults);
+  }
+
+  if (searchTerm || selectedSpecificNeeds.length > 0) {
+    searchResults = searchResults.map(item => {
+      item.resources = item.resources.filter(x => x.weight > 0);
+      return item;
+    });
+  }
+
+  searchResults = weightByCategories(selectedCategories, searchResults);
+
+  searchResults = flattenSearchResults(searchResults);
+  searchResults.resources.sort((a, b) => b.weight - a.weight);
+  return searchResults;
+};
+
 export {
   getSearchWithWeights,
   getWordsToHighlight,
@@ -207,5 +266,6 @@ export {
   weightByCategories,
   isJSON,
   filterOutExcludedWords,
-  getSpecificNeedsWords
+  getSpecificNeedsWords,
+  getSearchResult
 };

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -220,6 +220,28 @@ const flattenSearchResults = searchResults => {
   };
 };
 
+const weightByKeywords = (searchTerm, selectedCategories, selectedSpecificNeeds, resources) => {
+  let searchResults = resources;
+  if (searchTerm) {
+    searchResults = getSearchWithWeights(searchTerm, resources);
+  } else if (selectedCategories.length > 0) {
+    searchResults = getSearchWithWeights(selectedCategories.join(' '), resources);
+  }
+
+  if (selectedSpecificNeeds.length > 0) {
+    const specificNeedsWords = getSpecificNeedsWords(selectedSpecificNeeds);
+    searchResults = getSearchWithWeights(specificNeedsWords.join(' '), resources);
+  }
+  return searchResults;
+};
+
+const filterIrrelevantResults = searchResults => {
+  return searchResults.map(item => {
+    item.resources = item.resources.filter(x => x.weight > 0);
+    return item;
+  });
+};
+
 const getSearchResult = ({
   categorisedResources = [],
   searchTerm = '',
@@ -234,22 +256,15 @@ const getSearchResult = ({
     searchResults = filterOutExcludedWords(searchTerm, searchResults, selectedSpecificNeeds);
   }
 
-  if (searchTerm) {
-    searchResults = getSearchWithWeights(searchTerm, searchResults);
-  } else if (selectedCategories.length > 0) {
-    searchResults = getSearchWithWeights(selectedCategories.join(' '), searchResults);
-  }
-
-  if (selectedSpecificNeeds.length > 0) {
-    const specificNeedsWords = getSpecificNeedsWords(selectedSpecificNeeds);
-    searchResults = getSearchWithWeights(specificNeedsWords.join(' '), searchResults);
-  }
+  searchResults = weightByKeywords(
+    searchTerm,
+    selectedCategories,
+    selectedSpecificNeeds,
+    searchResults
+  );
 
   if (searchTerm || selectedSpecificNeeds.length > 0) {
-    searchResults = searchResults.map(item => {
-      item.resources = item.resources.filter(x => x.weight > 0);
-      return item;
-    });
+    searchResults = filterIrrelevantResults(searchResults);
   }
 
   searchResults = weightByCategories(selectedCategories, searchResults);

--- a/lib/utils/search.js
+++ b/lib/utils/search.js
@@ -22,10 +22,22 @@ const getExcludedWords = searchedWords => {
     .flat();
 };
 
-const getSearchWithWeights = (searchTerm, items) => {
+const getExcludedLabelsToWords = selectedLabels => {
+  const exclusions = isJSON(process.env.SEARCH_EXCLUSIONS)
+    ? JSON.parse(process.env.SEARCH_EXCLUSIONS)
+    : [];
+
+  return exclusions
+    .filter(exclusion => selectedLabels.includes(exclusion.label))
+    .map(exclusion => exclusion.excludeWords)
+    .flat();
+};
+
+const getSearchWithWeights = (searchTerm, items, selectedExcludedLabels = []) => {
   let normalisedSearchTerm = normalise(searchTerm.trim());
   let words = removeCommonWords(normalisedSearchTerm.split(' '));
-  let excludedWords = getExcludedWords(words);
+  let wordsToInclude = getExcludedLabelsToWords(selectedExcludedLabels);
+  let excludedWords = getExcludedWords(words.concat(wordsToInclude));
 
   return JSON.parse(JSON.stringify(items)).map(item => {
     item.resources = item.resources.map(resource => {

--- a/lib/utils/search.test.js
+++ b/lib/utils/search.test.js
@@ -2,7 +2,8 @@ import {
   getSearchWithWeights,
   getWordsToHighlight,
   filterByCategories,
-  weightByCategories
+  weightByCategories,
+  filterOutExcludedWords
 } from 'lib/utils/search';
 
 describe('search', () => {
@@ -378,11 +379,13 @@ describe('search', () => {
 
   describe('search exclusions', () => {
     it('excludes results containing terms configured to be excluded', () => {
-      const searchText = '';
-      const filteredServices = getSearchWithWeights(searchText, excludeTestsServices).map(item => {
-        item.resources = item.resources.filter(x => x.weight > 0);
-        return item;
-      });
+      const selectedSpecificNeeds = [];
+      const searchTerm = '';
+      const filteredServices = filterOutExcludedWords(
+        searchTerm,
+        excludeTestsServices,
+        selectedSpecificNeeds
+      );
       expect(filteredServices[0].resources.length).toBe(3);
       expect(filteredServices[0].resources.filter(x => x.name == 'giant ostrich').length).toEqual(
         0
@@ -391,12 +394,14 @@ describe('search', () => {
 
     it('ignores excluded words if the user searches for one of them', () => {
       const searchText = 'mrzombie';
-      const filteredServices = getSearchWithWeights(searchText, excludeTestsServices).map(item => {
-        item.resources = item.resources.filter(x => x.weight > 0);
-        return item;
-      });
+      const selectedSpecificNeeds = [];
+      const filteredServices = filterOutExcludedWords(
+        searchText,
+        excludeTestsServices,
+        selectedSpecificNeeds
+      );
 
-      expect(filteredServices[0].resources.length).toBe(1);
+      expect(filteredServices[0].resources.length).toBe(4);
       expect(filteredServices[0].resources.filter(x => x.name == 'giant ostrich').length).toEqual(
         1
       );
@@ -405,14 +410,9 @@ describe('search', () => {
     it('ignores excluded words if the user selects for one of them from checkbox', () => {
       const checked = ['Rick Grimes'];
       const searchText = 'giant ostrich';
-      const filteredServices = getSearchWithWeights(searchText, excludeTestsServices, checked).map(
-        item => {
-          item.resources = item.resources.filter(x => x.weight > 0);
-          return item;
-        }
-      );
+      const filteredServices = filterOutExcludedWords(searchText, excludeTestsServices, checked);
 
-      expect(filteredServices[0].resources.length).toBe(1);
+      expect(filteredServices[0].resources.length).toBe(4);
       expect(filteredServices[0].resources.filter(x => x.name == 'giant ostrich').length).toEqual(
         1
       );

--- a/lib/utils/search.test.js
+++ b/lib/utils/search.test.js
@@ -401,5 +401,21 @@ describe('search', () => {
         1
       );
     });
+
+    it('ignores excluded words if the user selects for one of them from checkbox', () => {
+      const checked = ['Rick Grimes'];
+      const searchText = 'giant ostrich';
+      const filteredServices = getSearchWithWeights(searchText, excludeTestsServices, checked).map(
+        item => {
+          item.resources = item.resources.filter(x => x.weight > 0);
+          return item;
+        }
+      );
+
+      expect(filteredServices[0].resources.length).toBe(1);
+      expect(filteredServices[0].resources.filter(x => x.name == 'giant ostrich').length).toEqual(
+        1
+      );
+    });
   });
 });

--- a/lib/utils/search.test.js
+++ b/lib/utils/search.test.js
@@ -3,7 +3,8 @@ import {
   getWordsToHighlight,
   filterByCategories,
   weightByCategories,
-  filterOutExcludedWords
+  filterOutExcludedWords,
+  getSearchResult
 } from 'lib/utils/search';
 
 describe('search', () => {
@@ -30,7 +31,7 @@ describe('search', () => {
           id: 3,
           name: 'I am not a service',
           description: 'Find services biscuit',
-          serviceDescription: 'Very good biscuit cheese vendor'
+          serviceDescription: 'Very good biscuit cheese vendor with some loneliness'
         },
         {
           id: 4,
@@ -416,6 +417,128 @@ describe('search', () => {
       expect(filteredServices[0].resources.filter(x => x.name == 'giant ostrich').length).toEqual(
         1
       );
+    });
+  });
+
+  describe('get search result', () => {
+    it('returns resources object containing an empty array if no categorised resources', () => {
+      const searchResult = getSearchResult({
+        categorisedResources: undefined,
+        searchTerm: '',
+        selectedCategories: [],
+        selectedSpecificNeeds: []
+      });
+      expect(searchResult.resources.length).toBe(0);
+      expect(searchResult.resources).toEqual([]);
+    });
+
+    it('returns resources object containing an empty array if categorised resources is an empty array', () => {
+      const searchResult = getSearchResult({
+        categorisedResources: [],
+        searchTerm: '',
+        selectedCategories: [],
+        selectedSpecificNeeds: []
+      });
+      expect(searchResult.resources.length).toBe(0);
+      expect(searchResult.resources).toEqual([]);
+    });
+
+    it('returns all resources if the search term is empty', () => {
+      const searchResult = getSearchResult({
+        categorisedResources: allServices,
+        searchTerm: ''
+      });
+
+      expect(searchResult.resources.length).toBe(5);
+    });
+
+    it('filters by selected categories and returns flattened result', () => {
+      const searchResult = getSearchResult({
+        categorisedResources: allServices,
+        selectedCategories: ['Loneliness']
+      });
+
+      expect(searchResult.resources.length).toBe(4);
+    });
+
+    it('filters out resources based on the search term', () => {
+      const searchResult = getSearchResult({
+        categorisedResources: allServices,
+        searchTerm: 'Big orc'
+      });
+
+      expect(searchResult.resources.length).toBe(1);
+      expect(searchResult.resources[0].id).toBe(1);
+    });
+
+    it('no search term is given it weights the resources with category names in description higher and sorts the result', () => {
+      const searchResult = getSearchResult({
+        categorisedResources: allServices,
+        selectedCategories: ['Loneliness']
+      });
+
+      expect(searchResult.resources.length).toBe(4);
+      expect(searchResult.resources[0].id).toBe(3);
+    });
+
+    it('does not exclude results if search term is empty', () => {
+      const searchResult = getSearchResult({ categorisedResources: excludeTestsServices });
+      expect(searchResult.resources.length).toBe(4);
+      expect(searchResult.resources.filter(x => x.name == 'giant ostrich').length).toEqual(1);
+    });
+
+    it('excludes results if search term is not empty', () => {
+      const searchResult = getSearchResult({
+        categorisedResources: excludeTestsServices,
+        searchTerm: ' '
+      });
+      expect(searchResult.resources.length).toBe(3);
+      expect(searchResult.resources.filter(x => x.name == 'giant ostrich').length).toEqual(0);
+    });
+
+    it('ignores excluded words if the user searches for one of them', () => {
+      const searchTerm = 'mrzombie';
+      const searchResult = getSearchResult({
+        categorisedResources: excludeTestsServices,
+        searchTerm
+      });
+
+      expect(searchResult.resources.length).toBe(1);
+      expect(searchResult.resources.filter(x => x.name == 'giant ostrich').length).toEqual(1);
+    });
+
+    it('ignores excluded words if the user selects for one of them from checkbox', () => {
+      const checked = ['Rick Grimes'];
+      const searchText = 'giant ostrich';
+      const searchResult = getSearchResult({
+        categorisedResources: excludeTestsServices,
+        searchTerm: searchText,
+        selectedSpecificNeeds: checked
+      });
+
+      expect(searchResult.resources.length).toBe(1);
+      expect(searchResult.resources.filter(x => x.name == 'giant ostrich').length).toEqual(1);
+    });
+
+    it('filters out resouces if only the checkbox is selected', () => {
+      const checked = ['Rick Grimes'];
+      const searchResult = getSearchResult({
+        categorisedResources: excludeTestsServices,
+        selectedSpecificNeeds: checked
+      });
+
+      expect(searchResult.resources.length).toBe(1);
+      expect(searchResult.resources.filter(x => x.name == 'giant ostrich').length).toEqual(1);
+    });
+
+    it('weights resource higher if it exists in more categories', () => {
+      const searchResult = getSearchResult({
+        categorisedResources: allServices,
+        selectedCategories: ['Loneliness', 'Cat2']
+      });
+
+      expect(searchResult.resources.length).toBe(5);
+      expect(searchResult.resources[0].id).toBe(4);
     });
   });
 });

--- a/mock-server/stubs/__files/fss_services.json
+++ b/mock-server/stubs/__files/fss_services.json
@@ -7,7 +7,7 @@
         {
           "id": 1,
           "name": "First category",
-          "description": "Help with first category from the first service mrzombie"
+          "description": "Help with first category from the first service"
         },
         {
           "id": 2,
@@ -101,6 +101,64 @@
       "referral": {
         "email": "",
         "website": "http://referal.form2.com"
+      },
+      "status": "active"
+    },
+    {
+      "id": 3,
+      "name": "Third service",
+      "categories": [
+        {
+          "id": 1,
+          "name": "First category",
+          "description": "Help with first category from the third service mrzombie"
+        },
+        {
+          "id": 2,
+          "name": "Second category",
+          "description": "Help with second category from the third service"
+        }
+      ],
+      "contact": {
+        "email": "help@gmail.com",
+        "telephone": "07000 0000000",
+        "website": "https://www.sample.org.uk"
+      },
+      "demographic": [
+        {
+          "id": 10,
+          "name": "Housing advice",
+          "vocabulary": "demographic"
+        },
+        {
+          "id": 19,
+          "name": "Cultural",
+          "vocabulary": "demographic"
+        }
+      ],
+      "description": "Third service description",
+      "locations": [
+        {
+          "latitude": 51.5466359,
+          "longitude": -0.0821704,
+          "uprn": "10093625362",
+          "address1": "404 error",
+          "address2": "not",
+          "city": "found",
+          "stateProvince": "",
+          "postalCode": "A1 2BC",
+          "country": "United Kingdom",
+          "distance": null
+        }
+      ],
+      "organization": {
+        "id": 1,
+        "name": "Organization Name",
+        "status": "published"
+      },
+      "referral": {
+        "email": "",
+        "website": "referal.form.com"
       },
       "status": "active"
     }

--- a/mock-server/stubs/__files/fss_services.json
+++ b/mock-server/stubs/__files/fss_services.json
@@ -7,7 +7,7 @@
         {
           "id": 1,
           "name": "First category",
-          "description": "Help with first category from the first service"
+          "description": "Help with first category from the first service mrzombie"
         },
         {
           "id": 2,


### PR DESCRIPTION
**What**  
Adding in new checkboxes to filter services for specific needs. Extracted out `filterOutExcludedWords` to remove services which contain excluded words.

![image](https://user-images.githubusercontent.com/32848419/131856733-7d8ff46e-ecf6-454b-91bb-ba5d198c0ad2.png)


**Why**  
Making it easier for users to filter services for specific needs
Ticket: BC2-119

**Anything else?**  
We fixed a bug introduced previously where excluded services weren't being filtered out by default when a category was clicked
Added in a new mock service to test service exclusions
