### PR TITLE
SSL Certificate Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ workflows:
           API_URL: ${NEXT_PUBLIC_API_URL_STAGING}
           aws-access-key-id: AWS_ACCESS_KEY_ID_STAGING
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY_STAGING
-          AWS_CERTIFICATE_ARN: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
+          AWS_CERTIFICATE_ARN: arn:aws:acm:us-east-1:715003523189:certificate/b2b8e94f-f6eb-4f1e-b443-6f005cddb218
           GTM_ID: ${NEXT_PUBLIC_STAGING_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_STAGING}
           INH_URL: ${INH_URL_STAGING}
@@ -208,7 +208,7 @@ workflows:
           API_URL: ${NEXT_PUBLIC_API_URL_PRODUCTION}
           aws-access-key-id: AWS_ACCESS_KEY_ID_PRODUCTION
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY_PRODUCTION
-          AWS_CERTIFICATE_ARN: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d
+          AWS_CERTIFICATE_ARN: arn:aws:acm:us-east-1:153306643385:certificate/e813d4c4-cdad-433f-8bf4-b0f668f3e970
           GTM_ID: ${NEXT_PUBLIC_GTM_ID}
           SINGLEVIEW_URL: ${NEXT_PUBLIC_SINGLEVIEW_URL_PRODUCTION}
           INH_URL: ${INH_URL_PRODUCTION}


### PR DESCRIPTION
# What:
- Updated certificate arns for AWS staging and production environments

# Why:
- The current SSL certificates expire at the end of today.  If the certificates are not updated, users will begin receive SSL warnings/errors in their browsers and in some cases the application will not load.
